### PR TITLE
DAT-37: ConnectorSettings.locateConnector "not found" error should leverage String.format completely

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -9,3 +9,4 @@
 - [new feature] DAT-17: Implement conversion service.
 - [improvement] DAT-29: Simplify way to select connector.
 - [improvement] DAT-30: Revisit bad files management.
+- [improvement] DAT-37: ConnectorSettings.locateConnector "not found" error should leverage String.format completely.

--- a/engine/src/main/java/com/datastax/loader/engine/internal/settings/ConnectorSettings.java
+++ b/engine/src/main/java/com/datastax/loader/engine/internal/settings/ConnectorSettings.java
@@ -38,9 +38,11 @@ public class ConnectorSettings {
         return connector;
     }
     throw new IllegalArgumentException(
-        String.format("Cannot find connector '%s'; available connectors are: ", name)
-            + StreamSupport.stream(connectors.spliterator(), false)
+        String.format(
+            "Cannot find connector '%s'; available connectors are: %s",
+            name,
+            StreamSupport.stream(connectors.spliterator(), false)
                 .map(connector -> connector.getClass().getName())
-                .collect(Collectors.joining(", ")));
+                .collect(Collectors.joining(", "))));
   }
 }


### PR DESCRIPTION
* Update how IllegalArgumentException is created in ConnectorSettings.locateConnector
  to have String.format do all the string concatenation work.