### PR TITLE
DAT-43: Boolean values should be parsed case-sensitive

### DIFF
--- a/engine/src/main/java/com/datastax/loader/engine/internal/codecs/StringToBooleanCodec.java
+++ b/engine/src/main/java/com/datastax/loader/engine/internal/codecs/StringToBooleanCodec.java
@@ -25,7 +25,7 @@ public class StringToBooleanCodec extends ConvertingCodec<String, Boolean> {
     if (s == null || s.isEmpty()) {
       return null;
     }
-    Boolean b = inputs.get(s.toLowerCase());
+    Boolean b = inputs.get(s);
     if (b == null) {
       throw new InvalidTypeException("Invalid boolean value: " + s);
     }

--- a/engine/src/main/java/com/datastax/loader/engine/internal/settings/CodecSettings.java
+++ b/engine/src/main/java/com/datastax/loader/engine/internal/settings/CodecSettings.java
@@ -93,7 +93,7 @@ public class CodecSettings {
 
   private final Config config;
 
-  public CodecSettings(Config config) {
+  CodecSettings(Config config) {
     this.config = config;
   }
 
@@ -204,8 +204,8 @@ public class CodecSettings {
         .map(str -> new StringTokenizer(str, ":"))
         .forEach(
             tokenizer -> {
-              builder.put(tokenizer.nextToken().toLowerCase(), true);
-              builder.put(tokenizer.nextToken().toLowerCase(), false);
+              builder.put(tokenizer.nextToken(), true);
+              builder.put(tokenizer.nextToken(), false);
             });
     return builder.build();
   }
@@ -213,8 +213,8 @@ public class CodecSettings {
   private static Map<Boolean, String> getBooleanOutputs(List<String> list) {
     StringTokenizer tokenizer = new StringTokenizer(list.get(0), ":");
     ImmutableMap.Builder<Boolean, String> builder = ImmutableMap.builder();
-    builder.put(true, tokenizer.nextToken().toLowerCase());
-    builder.put(false, tokenizer.nextToken().toLowerCase());
+    builder.put(true, tokenizer.nextToken());
+    builder.put(false, tokenizer.nextToken());
     return builder.build();
   }
 }

--- a/engine/src/main/resources/reference.conf
+++ b/engine/src/main/resources/reference.conf
@@ -329,9 +329,9 @@ datastax-loader {
     # Defaults to UTC.
     time-zone = UTC
 
-    # All possible combinations for true:false (case insensitive); the first combination is considered the default
+    # All possible combinations for true:false; the first combination is considered the default
     # and used when formatting.
-    boolean = ["1:0", "Y:N", "T:F", "YES:NO", "TRUE:FALSE"]
+    boolean = ["1:0", "Y:N", "y:n", "T:F", "t:f", "YES:NO", "yes:no", "Yes:No", "TRUE:FALSE", "true:false", "True:False"]
 
     # The DecimalFormat pattern to use for String-to-Number conversions.
     # See java.text.DecimalFormat for details about the pattern syntax to use.

--- a/engine/src/test/java/com/datastax/loader/engine/internal/codecs/StringToBooleanCodecTest.java
+++ b/engine/src/test/java/com/datastax/loader/engine/internal/codecs/StringToBooleanCodecTest.java
@@ -14,19 +14,15 @@ import org.junit.Test;
 
 public class StringToBooleanCodecTest {
 
-  Map<String, Boolean> inputs =
+  private Map<String, Boolean> inputs =
       ImmutableMap.<String, Boolean>builder().put("foo", true).put("bar", false).build();
-  Map<Boolean, String> outputs =
+  private Map<Boolean, String> outputs =
       ImmutableMap.<Boolean, String>builder().put(true, "foo").put(false, "bar").build();
   StringToBooleanCodec codec = new StringToBooleanCodec(inputs, outputs);
 
   @Test
   public void should_convert_from_valid_input() throws Exception {
     assertThat(codec)
-        .convertsFrom("FOO")
-        .to(true)
-        .convertsFrom("BAR")
-        .to(false)
         .convertsFrom("foo")
         .to(true)
         .convertsFrom("bar")
@@ -51,5 +47,8 @@ public class StringToBooleanCodecTest {
   @Test
   public void should_not_convert_from_invalid_input() throws Exception {
     assertThat(codec).cannotConvertFrom("not a valid boolean");
+
+    // The codec is case-sensitive.
+    assertThat(codec).cannotConvertFrom("FOO");
   }
 }

--- a/manual/engine/configuration/README.md
+++ b/manual/engine/configuration/README.md
@@ -373,8 +373,7 @@ The following options can be configured:
  
         All possible combinations for `true:false`; the first combination is considered the default
         and used when formatting.
-        Combinations are all case-insensitive.
-        Defaults to `["1:0", "Y:N", "T:F", "YES:NO", "TRUE:FALSE"]`
+        Defaults to `["1:0", "Y:N", "y:n", "T:F", "t:f", "YES:NO", "yes:no", "Yes:No", "TRUE:FALSE", "true:false", "True:False"]`
 
     * `number ` [string]
 


### PR DESCRIPTION
* Update default value for `codec.boolean` to include all interesting
  case-sensitive `true:false` pairings.
* Update string-boolean-codec and codec-parser to be case-sensitive.