### PR TITLE
DAT-31: Support String to Collection, UDT and Tuple conversion

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -19,3 +19,4 @@
 - [improvement] DAT-44: Do not block a thread while reading results.
 - [new feature] DAT-24: Add support for authentication and encryption.
 - [bug] DAT-48: Mappings are not being inferred.
+- [improvement] DAT-31: Support String to Collection, UDT and Tuple conversion.

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -71,6 +71,16 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-ffi</artifactId>
     </dependency>

--- a/engine/src/main/java/com/datastax/loader/engine/Main.java
+++ b/engine/src/main/java/com/datastax/loader/engine/Main.java
@@ -13,6 +13,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import com.datastax.driver.dse.DseCluster;
 import com.datastax.driver.dse.DseSession;
 import com.datastax.loader.connectors.api.Connector;
+import com.datastax.loader.engine.internal.codecs.ExtendedCodecRegistry;
 import com.datastax.loader.engine.internal.log.LogManager;
 import com.datastax.loader.engine.internal.metrics.MetricsManager;
 import com.datastax.loader.engine.internal.schema.RecordMapper;
@@ -88,12 +89,12 @@ public class Main {
             executorSettings.newWriteExecutor(session, metricsManager.getExecutionListener())) {
 
       session.init();
-      codecSettings.init(cluster);
       connector.init();
       metricsManager.init();
       logManager.init(cluster);
 
-      RecordMapper recordMapper = schemaSettings.newRecordMapper(session);
+      ExtendedCodecRegistry codecRegistry = codecSettings.init(cluster);
+      RecordMapper recordMapper = schemaSettings.init(session, codecRegistry);
 
       Flowable.fromPublisher(connector.read())
           .compose(metricsManager.newConnectorMonitor())

--- a/engine/src/main/java/com/datastax/loader/engine/internal/codecs/CodecUtils.java
+++ b/engine/src/main/java/com/datastax/loader/engine/internal/codecs/CodecUtils.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2017 DataStax Inc.
+ *
+ * This software can be used solely with DataStax Enterprise. Please consult the license at
+ * http://www.datastax.com/terms/datastax-dse-driver-license-terms
+ */
+package com.datastax.loader.engine.internal.codecs;
+
+import org.jetbrains.annotations.Nullable;
+
+class CodecUtils {
+
+  @Nullable
+  static String trimToNull(String s) {
+    if (s == null) {
+      return null;
+    }
+    s = s.trim();
+    return s.isEmpty() ? null : s;
+  }
+}

--- a/engine/src/main/java/com/datastax/loader/engine/internal/codecs/ConvertingCodec.java
+++ b/engine/src/main/java/com/datastax/loader/engine/internal/codecs/ConvertingCodec.java
@@ -9,6 +9,7 @@ package com.datastax.loader.engine.internal.codecs;
 import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.driver.core.exceptions.InvalidTypeException;
+import com.google.common.reflect.TypeToken;
 import java.nio.ByteBuffer;
 
 public abstract class ConvertingCodec<FROM, TO> extends TypeCodec<FROM> {
@@ -18,6 +19,10 @@ public abstract class ConvertingCodec<FROM, TO> extends TypeCodec<FROM> {
   protected ConvertingCodec(TypeCodec<TO> targetCodec, Class<FROM> javaType) {
     super(targetCodec.getCqlType(), javaType);
     this.targetCodec = targetCodec;
+  }
+
+  public TypeToken<TO> getTargetJavaType() {
+    return targetCodec.getJavaType();
   }
 
   @Override

--- a/engine/src/main/java/com/datastax/loader/engine/internal/codecs/ExtendedCodecRegistry.java
+++ b/engine/src/main/java/com/datastax/loader/engine/internal/codecs/ExtendedCodecRegistry.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright (C) 2017 DataStax Inc.
+ *
+ * This software can be used solely with DataStax Enterprise. Please consult the license at
+ * http://www.datastax.com/terms/datastax-dse-driver-license-terms
+ */
+package com.datastax.loader.engine.internal.codecs;
+
+import static com.datastax.driver.core.DataType.Name.ASCII;
+import static com.datastax.driver.core.DataType.Name.TEXT;
+import static com.datastax.driver.core.DataType.Name.VARCHAR;
+
+import com.datastax.driver.core.CodecRegistry;
+import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.TupleType;
+import com.datastax.driver.core.TupleValue;
+import com.datastax.driver.core.TypeCodec;
+import com.datastax.driver.core.UDTValue;
+import com.datastax.driver.core.UserType;
+import com.datastax.driver.core.exceptions.CodecNotFoundException;
+import com.datastax.driver.extras.codecs.jdk8.InstantCodec;
+import com.datastax.driver.extras.codecs.jdk8.LocalDateCodec;
+import com.datastax.driver.extras.codecs.jdk8.LocalTimeCodec;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.text.DecimalFormat;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.Temporal;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * If only CodecRegistry were extensible :(
+ *
+ * <p>This class helps solve the following problem: how to create codecs for combinations of Java
+ * types + CQL types that the original CodecRegistry cannot handle?
+ */
+public class ExtendedCodecRegistry {
+
+  private final CodecRegistry codecRegistry;
+  private final Map<String, Boolean> booleanInputs;
+  private final Map<Boolean, String> booleanOutputs;
+  private final ThreadLocal<DecimalFormat> numberFormat;
+  private final DateTimeFormatter localDateFormat;
+  private final DateTimeFormatter localTimeFormat;
+  private final DateTimeFormatter timestampFormat;
+  private final String delimiter;
+  private final String keyValueSeparator;
+
+  public ExtendedCodecRegistry(
+      CodecRegistry codecRegistry,
+      Map<String, Boolean> booleanInputs,
+      Map<Boolean, String> booleanOutputs,
+      ThreadLocal<DecimalFormat> numberFormat,
+      DateTimeFormatter localDateFormat,
+      DateTimeFormatter localTimeFormat,
+      DateTimeFormatter timestampFormat,
+      String delimiter,
+      String keyValueSeparator) {
+    this.codecRegistry = codecRegistry;
+    this.booleanInputs = booleanInputs;
+    this.booleanOutputs = booleanOutputs;
+    this.numberFormat = numberFormat;
+    this.localDateFormat = localDateFormat;
+    this.localTimeFormat = localTimeFormat;
+    this.timestampFormat = timestampFormat;
+    this.delimiter = delimiter;
+    this.keyValueSeparator = keyValueSeparator;
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T> TypeCodec<T> codecFor(
+      @NotNull DataType cqlType, @NotNull Class<? extends T> javaType) {
+    try {
+      return (TypeCodec<T>) codecRegistry.codecFor(cqlType, javaType);
+    } catch (CodecNotFoundException e) {
+      TypeCodec<T> codec = (TypeCodec<T>) maybeCreateCodec(cqlType, javaType);
+      if (codec != null) {
+        codecRegistry.register(codec);
+        return codec;
+      }
+      throw e;
+    }
+  }
+
+  @Nullable
+  private TypeCodec<?> maybeCreateCodec(@NotNull DataType cqlType, @NotNull Class<?> javaType) {
+    if (cqlType == DataType.date() && javaType.equals(LocalDate.class)) {
+      return LocalDateCodec.instance;
+    }
+    if (cqlType == DataType.time() && javaType.equals(LocalTimeCodec.class)) {
+      return LocalTimeCodec.instance;
+    }
+    if (cqlType == DataType.timestamp() && javaType.equals(Instant.class)) {
+      return InstantCodec.instance;
+    }
+    if (String.class.equals(javaType)) {
+      return createStringConvertingCodec(cqlType);
+    }
+    if (Number.class.isAssignableFrom(javaType) && isNumeric(cqlType)) {
+      //noinspection unchecked
+      Class<Number> numberType = (Class<Number>) javaType;
+      return new NumberToNumberCodec<>(numberType, codecRegistry.codecFor(cqlType));
+    }
+    if (Temporal.class.isAssignableFrom(javaType) && isTemporal(cqlType)) {
+      //noinspection unchecked
+      Class<Temporal> temporalType = (Class<Temporal>) javaType;
+      return new TemporalToTemporalCodec<>(temporalType, codecRegistry.codecFor(cqlType));
+    }
+    return null;
+  }
+
+  private TypeCodec<?> createStringConvertingCodec(@NotNull DataType cqlType) {
+    DataType.Name name = cqlType.getName();
+    switch (name) {
+      case BOOLEAN:
+        return new StringToBooleanCodec(booleanInputs, booleanOutputs);
+      case TINYINT:
+        return new StringToByteCodec(numberFormat);
+      case SMALLINT:
+        return new StringToShortCodec(numberFormat);
+      case INT:
+        return new StringToIntegerCodec(numberFormat);
+      case BIGINT:
+        return new StringToLongCodec(numberFormat);
+      case FLOAT:
+        return new StringToFloatCodec(numberFormat);
+      case DOUBLE:
+        return new StringToDoubleCodec(numberFormat);
+      case VARINT:
+        return new StringToBigIntegerCodec(numberFormat);
+      case DECIMAL:
+        return new StringToBigDecimalCodec(numberFormat);
+      case DATE:
+        return new StringToLocalDateCodec(localDateFormat);
+      case TIME:
+        return new StringToLocalTimeCodec(localTimeFormat);
+      case TIMESTAMP:
+        return new StringToInstantCodec(timestampFormat);
+      case INET:
+        return StringToInetAddressCodec.INSTANCE;
+      case UUID:
+        return new StringToUUIDCodec(TypeCodec.uuid());
+      case TIMEUUID:
+        return new StringToUUIDCodec(TypeCodec.timeUUID());
+      case LIST:
+        {
+          DataType elementType = cqlType.getTypeArguments().get(0);
+          TypeCodec<List<Object>> collectionCodec = codecRegistry.codecFor(cqlType);
+          ConvertingCodec<String, Object> eltCodec = stringConvertingCodecFor(elementType);
+          return new StringToListCodec<>(collectionCodec, eltCodec, delimiter);
+        }
+      case SET:
+        {
+          DataType elementType = cqlType.getTypeArguments().get(0);
+          TypeCodec<Set<Object>> collectionCodec = codecRegistry.codecFor(cqlType);
+          ConvertingCodec<String, Object> eltCodec = stringConvertingCodecFor(elementType);
+          return new StringToSetCodec<>(collectionCodec, eltCodec, delimiter);
+        }
+      case MAP:
+        {
+          DataType keyType = cqlType.getTypeArguments().get(0);
+          DataType valueType = cqlType.getTypeArguments().get(1);
+          TypeCodec<Map<Object, Object>> mapCodec = codecRegistry.codecFor(cqlType);
+          ConvertingCodec<String, Object> keyCodec = stringConvertingCodecFor(keyType);
+          ConvertingCodec<String, Object> valueCodec = stringConvertingCodecFor(valueType);
+          return new StringToMapCodec<>(
+              mapCodec, keyCodec, valueCodec, delimiter, keyValueSeparator);
+        }
+      case TUPLE:
+        {
+          TypeCodec<TupleValue> tupleCodec = codecRegistry.codecFor(cqlType);
+          ImmutableList.Builder<ConvertingCodec<String, Object>> eltCodecs =
+              new ImmutableList.Builder<>();
+          for (DataType eltType : ((TupleType) cqlType).getComponentTypes()) {
+            eltCodecs.add(stringConvertingCodecFor(eltType));
+          }
+          return new StringToTupleCodec(tupleCodec, eltCodecs.build(), delimiter);
+        }
+      case UDT:
+        {
+          TypeCodec<UDTValue> udtCodec = codecRegistry.codecFor(cqlType);
+          ImmutableMap.Builder<String, ConvertingCodec<String, Object>> fieldCodecs =
+              new ImmutableMap.Builder<>();
+          for (UserType.Field field : ((UserType) cqlType)) {
+            fieldCodecs.put(field.getName(), stringConvertingCodecFor(field.getType()));
+          }
+          return new StringToUDTCodec(udtCodec, fieldCodecs.build(), delimiter, keyValueSeparator);
+        }
+      default:
+        throw new AssertionError();
+    }
+  }
+
+  private <T> ConvertingCodec<String, T> stringConvertingCodecFor(DataType cqlType) {
+    // for text CQL types that map naturally to String, we need to wrap the returned codec in a dummy converting codec
+    if (cqlType.getName() == VARCHAR || cqlType.getName() == TEXT || cqlType.getName() == ASCII) {
+      //noinspection unchecked
+      return (ConvertingCodec<String, T>) new StringToStringCodec(codecRegistry.codecFor(cqlType));
+    }
+    // for all other CQL types it is guaranteed to be a converting codec
+    return (ConvertingCodec<String, T>) codecFor(cqlType, String.class);
+  }
+
+  private static boolean isNumeric(@NotNull DataType cqlType) {
+    return cqlType == DataType.tinyint()
+        || cqlType == DataType.smallint()
+        || cqlType == DataType.cint()
+        || cqlType == DataType.bigint()
+        || cqlType == DataType.cfloat()
+        || cqlType == DataType.cdouble()
+        || cqlType == DataType.varint()
+        || cqlType == DataType.decimal();
+  }
+
+  private static boolean isTemporal(@NotNull DataType cqlType) {
+    return cqlType == DataType.date()
+        || cqlType == DataType.time()
+        || cqlType == DataType.timestamp();
+  }
+
+  @VisibleForTesting
+  static class StringToStringCodec extends ConvertingCodec<String, String> {
+
+    @VisibleForTesting
+    StringToStringCodec(TypeCodec<String> innerCodec) {
+      super(innerCodec, String.class);
+    }
+
+    @Override
+    protected String convertFrom(String s) {
+      return s;
+    }
+
+    @Override
+    protected String convertTo(String value) {
+      return value;
+    }
+  }
+}

--- a/engine/src/main/java/com/datastax/loader/engine/internal/codecs/StringToCollectionCodec.java
+++ b/engine/src/main/java/com/datastax/loader/engine/internal/codecs/StringToCollectionCodec.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2017 DataStax Inc.
+ *
+ * This software can be used solely with DataStax Enterprise. Please consult the license at
+ * http://www.datastax.com/terms/datastax-dse-driver-license-terms
+ */
+package com.datastax.loader.engine.internal.codecs;
+
+import static com.datastax.loader.engine.internal.codecs.CodecUtils.trimToNull;
+
+import com.datastax.driver.core.TypeCodec;
+import com.google.common.base.Splitter;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class StringToCollectionCodec<E, C extends Collection<E>>
+    extends ConvertingCodec<String, C> {
+
+  private final ConvertingCodec<String, E> eltCodec;
+  private final String delimiter;
+
+  public StringToCollectionCodec(
+      TypeCodec<C> collectionCodec, ConvertingCodec<String, E> eltCodec, String delimiter) {
+    super(collectionCodec, String.class);
+    this.delimiter = delimiter;
+    this.eltCodec = eltCodec;
+  }
+
+  @Override
+  protected String convertTo(C value) {
+    if (value == null) {
+      return null;
+    }
+    StringBuilder sb = new StringBuilder();
+    for (Iterator<E> it = value.iterator(); it.hasNext(); ) {
+      String s = eltCodec.convertTo(it.next());
+      if (s != null) {
+        sb.append(s);
+      }
+      if (it.hasNext()) {
+        sb.append(delimiter);
+      }
+    }
+    return sb.toString();
+  }
+
+  @Override
+  protected C convertFrom(String s) {
+    if (s == null || s.isEmpty()) {
+      return null;
+    }
+    return StreamSupport.stream(Splitter.on(delimiter).trimResults().split(s).spliterator(), false)
+        .map(token -> eltCodec.convertFrom(trimToNull(token)))
+        .collect(Collectors.toCollection(collectionSupplier()));
+  }
+
+  @NotNull
+  protected abstract Supplier<C> collectionSupplier();
+}

--- a/engine/src/main/java/com/datastax/loader/engine/internal/codecs/StringToListCodec.java
+++ b/engine/src/main/java/com/datastax/loader/engine/internal/codecs/StringToListCodec.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2017 DataStax Inc.
+ *
+ * This software can be used solely with DataStax Enterprise. Please consult the license at
+ * http://www.datastax.com/terms/datastax-dse-driver-license-terms
+ */
+package com.datastax.loader.engine.internal.codecs;
+
+import com.datastax.driver.core.TypeCodec;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+import org.jetbrains.annotations.NotNull;
+
+public class StringToListCodec<E> extends StringToCollectionCodec<E, List<E>> {
+
+  public StringToListCodec(
+      TypeCodec<List<E>> collectionCodec, ConvertingCodec<String, E> eltCodec, String delimiter) {
+    super(collectionCodec, eltCodec, delimiter);
+  }
+
+  @NotNull
+  @Override
+  protected Supplier<List<E>> collectionSupplier() {
+    return ArrayList::new;
+  }
+}

--- a/engine/src/main/java/com/datastax/loader/engine/internal/codecs/StringToMapCodec.java
+++ b/engine/src/main/java/com/datastax/loader/engine/internal/codecs/StringToMapCodec.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2017 DataStax Inc.
+ *
+ * This software can be used solely with DataStax Enterprise. Please consult the license at
+ * http://www.datastax.com/terms/datastax-dse-driver-license-terms
+ */
+package com.datastax.loader.engine.internal.codecs;
+
+import com.datastax.driver.core.TypeCodec;
+import com.google.common.base.Splitter;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class StringToMapCodec<K, V> extends ConvertingCodec<String, Map<K, V>> {
+
+  private final ConvertingCodec<String, K> keyCodec;
+  private final ConvertingCodec<String, V> valueCodec;
+
+  private final String delimiter;
+  private final String keyValueSeparator;
+
+  public StringToMapCodec(
+      TypeCodec<Map<K, V>> collectionCodec,
+      ConvertingCodec<String, K> keyCodec,
+      ConvertingCodec<String, V> valueCodec,
+      String delimiter,
+      String keyValueSeparator) {
+    super(collectionCodec, String.class);
+    this.valueCodec = valueCodec;
+    this.delimiter = delimiter;
+    this.keyCodec = keyCodec;
+    this.keyValueSeparator = keyValueSeparator;
+  }
+
+  @Override
+  protected String convertTo(Map<K, V> map) {
+    if (map == null) {
+      return null;
+    }
+    StringBuilder sb = new StringBuilder();
+    for (Iterator<Map.Entry<K, V>> it = map.entrySet().iterator(); it.hasNext(); ) {
+      Map.Entry<K, V> entry = it.next();
+      String key = keyCodec.convertTo(entry.getKey());
+      String value = valueCodec.convertTo(entry.getValue());
+      sb.append(key == null ? "" : key)
+          .append(keyValueSeparator)
+          .append(value == null ? "" : value);
+      if (it.hasNext()) {
+        sb.append(delimiter);
+      }
+    }
+    return sb.toString();
+  }
+
+  @Override
+  protected Map<K, V> convertFrom(String s) {
+    if (s == null || s.isEmpty()) {
+      return null;
+    }
+    Map<String, String> raw =
+        Splitter.on(delimiter).trimResults().withKeyValueSeparator(keyValueSeparator).split(s);
+    Map<K, V> map = new LinkedHashMap<>(raw.size());
+    for (Map.Entry<String, String> entry : raw.entrySet()) {
+      map.put(
+          keyCodec.convertFrom(CodecUtils.trimToNull(entry.getKey())),
+          valueCodec.convertFrom(CodecUtils.trimToNull(entry.getValue())));
+    }
+    return map;
+  }
+}

--- a/engine/src/main/java/com/datastax/loader/engine/internal/codecs/StringToSetCodec.java
+++ b/engine/src/main/java/com/datastax/loader/engine/internal/codecs/StringToSetCodec.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2017 DataStax Inc.
+ *
+ * This software can be used solely with DataStax Enterprise. Please consult the license at
+ * http://www.datastax.com/terms/datastax-dse-driver-license-terms
+ */
+package com.datastax.loader.engine.internal.codecs;
+
+import com.datastax.driver.core.TypeCodec;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.function.Supplier;
+import org.jetbrains.annotations.NotNull;
+
+public class StringToSetCodec<E> extends StringToCollectionCodec<E, Set<E>> {
+
+  public StringToSetCodec(
+      TypeCodec<Set<E>> collectionCodec, ConvertingCodec<String, E> eltCodec, String delimiter) {
+    super(collectionCodec, eltCodec, delimiter);
+  }
+
+  @NotNull
+  @Override
+  protected Supplier<Set<E>> collectionSupplier() {
+    return LinkedHashSet::new;
+  }
+}

--- a/engine/src/main/java/com/datastax/loader/engine/internal/codecs/StringToTupleCodec.java
+++ b/engine/src/main/java/com/datastax/loader/engine/internal/codecs/StringToTupleCodec.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2017 DataStax Inc.
+ *
+ * This software can be used solely with DataStax Enterprise. Please consult the license at
+ * http://www.datastax.com/terms/datastax-dse-driver-license-terms
+ */
+package com.datastax.loader.engine.internal.codecs;
+
+import static com.datastax.loader.engine.internal.codecs.CodecUtils.trimToNull;
+
+import com.datastax.driver.core.TupleType;
+import com.datastax.driver.core.TupleValue;
+import com.datastax.driver.core.TypeCodec;
+import com.google.common.base.Splitter;
+import java.util.List;
+
+public class StringToTupleCodec extends ConvertingCodec<String, TupleValue> {
+
+  private final TupleType definition;
+  private final List<ConvertingCodec<String, Object>> eltCodecs;
+  private final String delimiter;
+
+  public StringToTupleCodec(
+      TypeCodec<TupleValue> tupleCodec,
+      List<ConvertingCodec<String, Object>> eltCodecs,
+      String delimiter) {
+    super(tupleCodec, String.class);
+    this.eltCodecs = eltCodecs;
+    this.delimiter = delimiter;
+    definition = (TupleType) tupleCodec.getCqlType();
+  }
+
+  @Override
+  protected String convertTo(TupleValue value) {
+    if (value == null) {
+      return null;
+    }
+    StringBuilder sb = new StringBuilder();
+    int size = definition.getComponentTypes().size();
+    for (int i = 0; i < size; i++) {
+      if (i > 0) {
+        sb.append(delimiter);
+      }
+      ConvertingCodec<String, Object> eltCodec = eltCodecs.get(i);
+      Object o = value.get(i, eltCodec.getTargetJavaType());
+      String s = eltCodec.convertTo(o);
+      if (s != null) {
+        sb.append(s);
+      }
+    }
+    return sb.toString();
+  }
+
+  @Override
+  protected TupleValue convertFrom(String s) {
+    if (s == null || s.isEmpty()) {
+      return null;
+    }
+    List<String> elts = Splitter.on(delimiter).trimResults().splitToList(s);
+    TupleValue value = definition.newValue();
+    for (int i = 0; i < definition.getComponentTypes().size(); i++) {
+      ConvertingCodec<String, Object> eltCodec = eltCodecs.get(i);
+      Object o = eltCodec.convertFrom(trimToNull(elts.get(i)));
+      value.set(i, o, eltCodec.getTargetJavaType());
+    }
+    return value;
+  }
+}

--- a/engine/src/main/java/com/datastax/loader/engine/internal/codecs/StringToUDTCodec.java
+++ b/engine/src/main/java/com/datastax/loader/engine/internal/codecs/StringToUDTCodec.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2017 DataStax Inc.
+ *
+ * This software can be used solely with DataStax Enterprise. Please consult the license at
+ * http://www.datastax.com/terms/datastax-dse-driver-license-terms
+ */
+package com.datastax.loader.engine.internal.codecs;
+
+import static com.datastax.loader.engine.internal.codecs.CodecUtils.trimToNull;
+
+import com.datastax.driver.core.TypeCodec;
+import com.datastax.driver.core.UDTValue;
+import com.datastax.driver.core.UserType;
+import com.datastax.driver.core.exceptions.InvalidTypeException;
+import com.google.common.base.Splitter;
+import java.util.Iterator;
+import java.util.Map;
+
+public class StringToUDTCodec extends ConvertingCodec<String, UDTValue> {
+
+  private final Map<String, ConvertingCodec<String, Object>> fieldCodecs;
+  private final UserType definition;
+
+  private final String delimiter;
+  private final String keyValueSeparator;
+
+  public StringToUDTCodec(
+      TypeCodec<UDTValue> udtCodec,
+      Map<String, ConvertingCodec<String, Object>> fieldCodecs,
+      String delimiter,
+      String keyValueSeparator) {
+    super(udtCodec, String.class);
+    this.fieldCodecs = fieldCodecs;
+    this.delimiter = delimiter;
+    this.keyValueSeparator = keyValueSeparator;
+    definition = (UserType) udtCodec.getCqlType();
+  }
+
+  @Override
+  protected String convertTo(UDTValue value) {
+    if (value == null) {
+      return null;
+    }
+    StringBuilder sb = new StringBuilder();
+    for (Iterator<UserType.Field> it = definition.iterator(); it.hasNext(); ) {
+      UserType.Field field = it.next();
+      String name = field.getName();
+      ConvertingCodec<String, Object> eltCodec = fieldCodecs.get(name);
+      Object o = value.get(name, eltCodec.getTargetJavaType());
+      String s = eltCodec.convertTo(o);
+      sb.append(name).append(keyValueSeparator).append(s == null ? "" : s);
+      if (it.hasNext()) {
+        sb.append(delimiter);
+      }
+    }
+    return sb.toString();
+  }
+
+  @Override
+  protected UDTValue convertFrom(String s) {
+    if (s == null || s.isEmpty()) {
+      return null;
+    }
+    Map<String, String> map =
+        Splitter.on(delimiter).trimResults().withKeyValueSeparator(keyValueSeparator).split(s);
+    UDTValue value = definition.newValue();
+    for (Map.Entry<String, String> entry : map.entrySet()) {
+      String name = trimToNull(entry.getKey());
+      if (definition.getFieldType(name) == null) {
+        throw new InvalidTypeException(
+            String.format("Unknown field %s in UDT %s", name, definition.getName()));
+      }
+      ConvertingCodec<String, Object> fieldCodec = fieldCodecs.get(name);
+      Object o = fieldCodec.convertFrom(trimToNull(entry.getValue()));
+      value.set(name, o, fieldCodec.getTargetJavaType());
+    }
+    return value;
+  }
+}

--- a/engine/src/main/java/com/datastax/loader/engine/internal/schema/DefaultMapping.java
+++ b/engine/src/main/java/com/datastax/loader/engine/internal/schema/DefaultMapping.java
@@ -6,12 +6,41 @@
  */
 package com.datastax.loader.engine.internal.schema;
 
-import java.util.LinkedHashMap;
+import com.datastax.driver.core.ColumnDefinitions;
+import com.datastax.driver.core.TypeCodec;
+import com.datastax.loader.engine.internal.codecs.ExtendedCodecRegistry;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.collect.ImmutableMap;
 
-public class DefaultMapping extends LinkedHashMap<Object, String> implements Mapping {
+public class DefaultMapping implements Mapping {
+
+  private final ImmutableMap<Object, String> fieldsToVariables;
+  private final ExtendedCodecRegistry codecRegistry;
+  private final ColumnDefinitions variables;
+  private final Cache<String, TypeCodec<Object>> variablesToCodecs;
+
+  public DefaultMapping(
+      ImmutableMap<Object, String> fieldsToVariables,
+      ExtendedCodecRegistry codecRegistry,
+      ColumnDefinitions variables) {
+    this.fieldsToVariables = fieldsToVariables;
+    this.codecRegistry = codecRegistry;
+    this.variables = variables;
+    variablesToCodecs = Caffeine.newBuilder().build();
+  }
 
   @Override
   public String map(Object field) {
-    return get(field);
+    return fieldsToVariables.get(field);
+  }
+
+  @Override
+  public TypeCodec<Object> codec(String name, Object raw) {
+    TypeCodec<Object> codec =
+        variablesToCodecs.get(
+            name, n -> codecRegistry.codecFor(variables.getType(n), raw.getClass()));
+    assert codec != null;
+    return codec;
   }
 }

--- a/engine/src/main/java/com/datastax/loader/engine/internal/schema/Mapping.java
+++ b/engine/src/main/java/com/datastax/loader/engine/internal/schema/Mapping.java
@@ -6,6 +6,10 @@
  */
 package com.datastax.loader.engine.internal.schema;
 
+import com.datastax.driver.core.TypeCodec;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 public interface Mapping {
 
   /**
@@ -16,5 +20,16 @@ public interface Mapping {
    * @return the bound variable name the given field maps to, or {@code null} if the field does not
    *     map to any known bound variable.
    */
-  String map(Object field);
+  @Nullable
+  String map(@NotNull Object field);
+
+  /**
+   * Returns the codec to use for the given bound variable.
+   *
+   * @param name the bound variable name; never {@code null}.
+   * @param raw The raw value to find a codec for, as emitted by the connector; never {@code null}.
+   * @return the codec to use; never {@code null}.
+   */
+  @NotNull
+  TypeCodec<Object> codec(@NotNull String name, @NotNull Object raw);
 }

--- a/engine/src/main/java/com/datastax/loader/engine/internal/schema/RecordMapper.java
+++ b/engine/src/main/java/com/datastax/loader/engine/internal/schema/RecordMapper.java
@@ -129,7 +129,7 @@ public class RecordMapper {
       bs.setToNull(variable);
     } else {
       //noinspection unchecked
-      bs.set(variable, convertedValue, (Class<Object>) convertedValue.getClass());
+      bs.set(variable, convertedValue, mapping.codec(variable, convertedValue));
     }
   }
 }

--- a/engine/src/main/java/com/datastax/loader/engine/internal/settings/SchemaSettings.java
+++ b/engine/src/main/java/com/datastax/loader/engine/internal/settings/SchemaSettings.java
@@ -12,9 +12,11 @@ import com.datastax.driver.core.Metadata;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.TableMetadata;
+import com.datastax.loader.engine.internal.codecs.ExtendedCodecRegistry;
 import com.datastax.loader.engine.internal.schema.DefaultMapping;
 import com.datastax.loader.engine.internal.schema.RecordMapper;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -35,10 +37,10 @@ public class SchemaSettings {
     this.config = config;
   }
 
-  public RecordMapper newRecordMapper(Session session) {
-    DefaultMapping mapping = null;
+  public RecordMapper init(Session session, ExtendedCodecRegistry codecRegistry) {
+    ImmutableMap.Builder<Object, String> fieldsToVariablesBuilder = null;
     if (config.hasPath("mapping") && !config.getConfig("mapping").isEmpty()) {
-      mapping = new DefaultMapping();
+      fieldsToVariablesBuilder = new ImmutableMap.Builder<>();
       for (Map.Entry<String, Object> entry :
           config.getConfig("mapping").root().unwrapped().entrySet()) {
         Object key = entry.getKey();
@@ -48,7 +50,7 @@ public class SchemaSettings {
           key = Integer.valueOf(key.toString());
         } catch (NumberFormatException ignored) {
         }
-        mapping.put(key, entry.getValue().toString());
+        fieldsToVariablesBuilder.put(key, entry.getValue().toString());
       }
     }
     if (config.hasPath("keyspace")) {
@@ -63,44 +65,47 @@ public class SchemaSettings {
     }
     if (!config.hasPath("mapping") || config.getConfig("mapping").isEmpty()) {
       Preconditions.checkState(keyspace != null && table != null);
-      mapping = inferMapping();
+      fieldsToVariablesBuilder = inferFieldsToVariablesMap();
     }
     Preconditions.checkNotNull(
-        mapping,
+        fieldsToVariablesBuilder,
         "Mapping was absent and could not be inferred, please provide an explicit mapping");
+    ImmutableMap<Object, String> fieldsToVariables = fieldsToVariablesBuilder.build();
     String query;
     if (config.hasPath("statement")) {
       query = config.getString("statement");
     } else {
       Preconditions.checkState(
           keyspace != null && table != null, "Keyspace and table must be specified");
-      query = inferQuery(mapping);
+      query = inferQuery(fieldsToVariables);
     }
     PreparedStatement ps = session.prepare(query);
+    DefaultMapping mapping =
+        new DefaultMapping(fieldsToVariables, codecRegistry, ps.getVariables());
     return new RecordMapper(
         ps, mapping, config.getStringList("nullWords"), config.getBoolean("nullToUnset"));
   }
 
-  private DefaultMapping inferMapping() {
-    DefaultMapping mapping = new DefaultMapping();
+  private ImmutableMap.Builder<Object, String> inferFieldsToVariablesMap() {
+    ImmutableMap.Builder<Object, String> fieldsToVariables = new ImmutableMap.Builder<>();
     for (int i = 0; i < table.getColumns().size(); i++) {
       ColumnMetadata col = table.getColumns().get(i);
       String name = Metadata.quoteIfNecessary(col.getName());
       // use both indexed and mapped access
       // indexed access can only work if the data source produces
       // indexed records with columns in the same order
-      mapping.put(i, name);
-      mapping.put(col.getName(), name);
+      fieldsToVariables.put(i, name);
+      fieldsToVariables.put(col.getName(), name);
     }
-    return mapping;
+    return fieldsToVariables;
   }
 
-  private String inferQuery(DefaultMapping mapping) {
+  private String inferQuery(ImmutableMap<Object, String> fieldsToVariables) {
     StringBuilder sb = new StringBuilder("INSERT INTO ");
     sb.append(keyspaceName).append('.').append(tableName).append('(');
     // de-dup in case the mapping has both indexed and mapped entries
     // for the same bound variable
-    Set<String> cols = new LinkedHashSet<>(mapping.values());
+    Set<String> cols = new LinkedHashSet<>(fieldsToVariables.values());
     Iterator<String> it = cols.iterator();
     while (it.hasNext()) {
       // this assumes that the variable name found in the mapping

--- a/engine/src/main/resources/reference.conf
+++ b/engine/src/main/resources/reference.conf
@@ -439,7 +439,7 @@ datastax-loader {
     }
   }
 
-  # Conversion-specific settings
+  # Conversion-specific settings.
   codec {
 
     # The locale to use for locale-sensitive conversions.
@@ -488,6 +488,24 @@ datastax-loader {
     # Defaults to ISO_LOCAL_TIME.
     time = "ISO_LOCAL_TIME"
 
+    # The delimiter for tokenized fields.
+    # This setting will be used when mapping a String field to
+    # CQL columns that require special tokenization (collections, tuples and UDTs),
+    # to isolate elements in the string.
+    # Note that this is not the same as CSV parsing.
+    # This setting will be applied to record fields produced by any connector,
+    # as long as the the target CQL type requires tokenization.
+    # Defaults to "," (comma).
+    delimiter = ","
+
+    # The key-value separator to use to split keys and values in a tokenized field.
+    # This setting will be used when mapping a String field to
+    # CQL columns of type map or UDT, to isolate keys/fields from values, after key-value pairs
+    # have been tokenized using the "delimiter" setting.
+    # This setting will be applied to record fields produced by any connector,
+    # as long as the the target CQL type requires key-value tokenization.
+    # Defaults to ":" (colon).
+    keyValueSeparator = ":"
   }
 
   # Monitoring-specific settings.

--- a/engine/src/test/java/com/datastax/driver/core/DriverCoreTestHooks.java
+++ b/engine/src/test/java/com/datastax/driver/core/DriverCoreTestHooks.java
@@ -6,10 +6,40 @@
  */
 package com.datastax.driver.core;
 
+import java.util.Arrays;
+
 /** */
 public class DriverCoreTestHooks {
 
   public static PreparedId newPreparedId(ColumnDefinitions cd, ProtocolVersion version) {
     return new PreparedId(null, cd, null, null, version);
+  }
+
+  public static TupleType newTupleType(DataType... types) {
+    return newTupleType(ProtocolVersion.NEWEST_SUPPORTED, CodecRegistry.DEFAULT_INSTANCE, types);
+  }
+
+  public static TupleType newTupleType(
+      ProtocolVersion protocolVersion, CodecRegistry codecRegistry, DataType... types) {
+    return new TupleType(Arrays.asList(types), protocolVersion, codecRegistry);
+  }
+
+  public static UserType newUserType(UserType.Field... fields) {
+    return newUserType(
+        "ks", "udt", ProtocolVersion.NEWEST_SUPPORTED, CodecRegistry.DEFAULT_INSTANCE, fields);
+  }
+
+  public static UserType newUserType(
+      String keyspace,
+      String typeName,
+      ProtocolVersion protocolVersion,
+      CodecRegistry codecRegistry,
+      UserType.Field... fields) {
+    return new UserType(
+        keyspace, typeName, true, Arrays.asList(fields), protocolVersion, codecRegistry);
+  }
+
+  public static UserType.Field newField(String name, DataType type) {
+    return new UserType.Field(name, type);
   }
 }

--- a/engine/src/test/java/com/datastax/loader/engine/internal/codecs/ConvertingCodecAssert.java
+++ b/engine/src/test/java/com/datastax/loader/engine/internal/codecs/ConvertingCodecAssert.java
@@ -6,9 +6,9 @@
  */
 package com.datastax.loader.engine.internal.codecs;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ObjectAssert;
 
 public class ConvertingCodecAssert<FROM, TO> extends ObjectAssert<ConvertingCodec<FROM, TO>> {
@@ -77,8 +77,8 @@ public class ConvertingCodecAssert<FROM, TO> extends ObjectAssert<ConvertingCode
     }
 
     public ConvertingCodecAssert<FROM, TO> to(TO to) {
-      Assertions.assertThat(this.to)
-          .as("Expecting codec to convert from %s to %s but it was to %s", from, to, this.to)
+      assertThat(this.to)
+          .as("Expecting codec to convert to %s from %s but it was to %s", to, from, this.to)
           .isEqualTo(to);
       return this;
     }
@@ -96,7 +96,7 @@ public class ConvertingCodecAssert<FROM, TO> extends ObjectAssert<ConvertingCode
     }
 
     public ConvertingCodecAssert<FROM, TO> from(FROM from) {
-      Assertions.assertThat(this.from)
+      assertThat(this.from)
           .as("Expecting codec to convert to %s from %s but it was from %s", to, from, this.from)
           .isEqualTo(from);
       return this;

--- a/engine/src/test/java/com/datastax/loader/engine/internal/codecs/NumberToNumberCodecTest.java
+++ b/engine/src/test/java/com/datastax/loader/engine/internal/codecs/NumberToNumberCodecTest.java
@@ -69,7 +69,7 @@ public class NumberToNumberCodecTest {
         .from(null);
 
     assertThat(new NumberToNumberCodec<>(BigDecimal.class, TypeCodec.cint()))
-        .convertsFrom(new BigDecimal("123.00"))
+        .convertsFrom(new BigDecimal("123"))
         .to(123)
         .convertsFrom(null)
         .to(null)

--- a/engine/src/test/java/com/datastax/loader/engine/internal/codecs/StringToListCodecTest.java
+++ b/engine/src/test/java/com/datastax/loader/engine/internal/codecs/StringToListCodecTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2017 DataStax Inc.
+ *
+ * This software can be used solely with DataStax Enterprise. Please consult the license at
+ * http://www.datastax.com/terms/datastax-dse-driver-license-terms
+ */
+package com.datastax.loader.engine.internal.codecs;
+
+import static com.datastax.driver.core.TypeCodec.cdouble;
+import static com.datastax.driver.core.TypeCodec.list;
+import static com.datastax.driver.core.TypeCodec.varchar;
+import static com.datastax.loader.engine.internal.Assertions.assertThat;
+
+import com.datastax.driver.core.TypeCodec;
+import com.google.common.collect.Lists;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+import org.junit.Test;
+
+public class StringToListCodecTest {
+
+  private StringToDoubleCodec eltCodec1 =
+      new StringToDoubleCodec(
+          ThreadLocal.withInitial(
+              () -> new DecimalFormat("#,###.##", DecimalFormatSymbols.getInstance(Locale.US))));
+
+  private ExtendedCodecRegistry.StringToStringCodec eltCodec2 =
+      new ExtendedCodecRegistry.StringToStringCodec(TypeCodec.varchar());
+
+  private StringToListCodec<Double> codec1 =
+      new StringToListCodec<>(list(cdouble()), eltCodec1, "|");
+  private StringToListCodec<String> codec2 =
+      new StringToListCodec<>(list(varchar()), eltCodec2, "|");
+
+  @Test
+  public void should_convert_from_valid_input() throws Exception {
+    assertThat(codec1)
+        .convertsFrom("1|2|3")
+        .to(Lists.newArrayList(1d, 2d, 3d))
+        .convertsFrom("1 | 2 | 3")
+        .to(Lists.newArrayList(1d, 2d, 3d))
+        .convertsFrom("1,234.56|78,900")
+        .to(Lists.newArrayList(1234.56d, 78900d))
+        .convertsFrom("|")
+        .to(Lists.newArrayList(null, null))
+        .convertsFrom(null)
+        .to(null)
+        .convertsFrom("")
+        .to(null);
+    assertThat(codec2)
+        .convertsFrom("foo|bar")
+        .to(Lists.newArrayList("foo", "bar"))
+        .convertsFrom(" foo | bar ")
+        .to(Lists.newArrayList("foo", "bar"))
+        .convertsFrom("|")
+        .to(Lists.newArrayList(null, null))
+        .convertsFrom(null)
+        .to(null)
+        .convertsFrom("")
+        .to(null);
+  }
+
+  @Test
+  public void should_convert_to_valid_input() throws Exception {
+    assertThat(codec1)
+        .convertsTo(Lists.newArrayList(1d, 2d, 3d))
+        .from("1|2|3")
+        .convertsTo(Lists.newArrayList(1234.56d, 78900d))
+        .from("1,234.56|78,900")
+        .convertsTo(Lists.newArrayList(1d, null))
+        .from("1|")
+        .convertsTo(Lists.newArrayList(null, 0d))
+        .from("|0")
+        .convertsTo(Lists.newArrayList(null, null))
+        .from("|")
+        .convertsTo(null)
+        .from(null);
+    assertThat(codec2)
+        .convertsTo(Lists.newArrayList("foo", "bar"))
+        .from("foo|bar")
+        .convertsTo(Lists.newArrayList(null, null))
+        .from("|")
+        .convertsTo(null)
+        .from(null);
+  }
+
+  @Test
+  public void should_not_convert_from_invalid_input() throws Exception {
+    assertThat(codec1).cannotConvertFrom("1|not a valid double");
+  }
+}

--- a/engine/src/test/java/com/datastax/loader/engine/internal/codecs/StringToMapCodecTest.java
+++ b/engine/src/test/java/com/datastax/loader/engine/internal/codecs/StringToMapCodecTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2017 DataStax Inc.
+ *
+ * This software can be used solely with DataStax Enterprise. Please consult the license at
+ * http://www.datastax.com/terms/datastax-dse-driver-license-terms
+ */
+package com.datastax.loader.engine.internal.codecs;
+
+import static com.datastax.loader.engine.internal.Assertions.assertThat;
+
+import com.datastax.driver.core.TypeCodec;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import org.junit.Test;
+
+public class StringToMapCodecTest {
+
+  private ConvertingCodec keyCodec =
+      new StringToDoubleCodec(
+          ThreadLocal.withInitial(
+              () -> new DecimalFormat("#,###.##", DecimalFormatSymbols.getInstance(Locale.US))));
+
+  private ConvertingCodec valueCodec =
+      new ExtendedCodecRegistry.StringToStringCodec(TypeCodec.varchar());
+
+  @SuppressWarnings("unchecked")
+  private StringToMapCodec<Double, String> codec =
+      new StringToMapCodec<Double, String>(
+          TypeCodec.map(TypeCodec.cdouble(), TypeCodec.varchar()), keyCodec, valueCodec, ";", ":");
+
+  @Test
+  public void should_convert_from_valid_input() throws Exception {
+    assertThat(codec)
+        .convertsFrom("1:foo;2:bar")
+        .to(newLinkedHashMap(1d, "foo", 2d, "bar"))
+        .convertsFrom("1,234.56:foo;0.12:bar")
+        .to(newLinkedHashMap(1234.56d, "foo", 0.12d, "bar"))
+        .convertsFrom(" 1 : foo ; 2 : bar ")
+        .to(newLinkedHashMap(1d, "foo", 2d, "bar"))
+        .convertsFrom("1:;:foo")
+        .to(newLinkedHashMap(1d, null, null, "foo"))
+        .convertsFrom(":foo;1:")
+        .to(newLinkedHashMap(null, "foo", 1d, null))
+        .convertsFrom(null)
+        .to(null)
+        .convertsFrom("")
+        .to(null);
+  }
+
+  @Test
+  public void should_convert_to_valid_input() throws Exception {
+    assertThat(codec)
+        .convertsTo(newLinkedHashMap(1d, "foo", 2d, "bar"))
+        .from("1:foo;2:bar")
+        .convertsTo(newLinkedHashMap(1d, null, null, "foo"))
+        .from("1:;:foo")
+        .convertsTo(null)
+        .from(null);
+  }
+
+  @Test
+  public void should_not_convert_from_invalid_input() throws Exception {
+    assertThat(codec).cannotConvertFrom("not a valid input").cannotConvertFrom("not a;valid input");
+  }
+
+  private static Map<Double, String> newLinkedHashMap(Double k1, String v1, Double k2, String v2) {
+    Map<Double, String> map = new LinkedHashMap<>();
+    map.put(k1, v1);
+    map.put(k2, v2);
+    return map;
+  }
+}

--- a/engine/src/test/java/com/datastax/loader/engine/internal/codecs/StringToSetCodecTest.java
+++ b/engine/src/test/java/com/datastax/loader/engine/internal/codecs/StringToSetCodecTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2017 DataStax Inc.
+ *
+ * This software can be used solely with DataStax Enterprise. Please consult the license at
+ * http://www.datastax.com/terms/datastax-dse-driver-license-terms
+ */
+package com.datastax.loader.engine.internal.codecs;
+
+import static com.datastax.driver.core.TypeCodec.cdouble;
+import static com.datastax.driver.core.TypeCodec.set;
+import static com.datastax.driver.core.TypeCodec.varchar;
+import static com.datastax.loader.engine.internal.Assertions.assertThat;
+
+import com.datastax.driver.core.TypeCodec;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+import org.junit.Test;
+
+public class StringToSetCodecTest {
+
+  private StringToDoubleCodec eltCodec1 =
+      new StringToDoubleCodec(
+          ThreadLocal.withInitial(
+              () -> new DecimalFormat("#,###.##", DecimalFormatSymbols.getInstance(Locale.US))));
+
+  private ExtendedCodecRegistry.StringToStringCodec eltCodec2 =
+      new ExtendedCodecRegistry.StringToStringCodec(TypeCodec.varchar());
+
+  private StringToSetCodec<Double> codec1 = new StringToSetCodec<>(set(cdouble()), eltCodec1, "|");
+  private StringToSetCodec<String> codec2 = new StringToSetCodec<>(set(varchar()), eltCodec2, "|");
+
+  @Test
+  public void should_convert_from_valid_input() throws Exception {
+    assertThat(codec1)
+        .convertsFrom("1|2|3")
+        .to(Sets.newHashSet(1d, 2d, 3d))
+        .convertsFrom("1 | 2 | 3")
+        .to(Sets.newHashSet(1d, 2d, 3d))
+        .convertsFrom("1,234.56|78,900")
+        .to(Sets.newHashSet(1234.56d, 78900d))
+        .convertsFrom("|")
+        .to(Sets.newHashSet(null, null))
+        .convertsFrom(null)
+        .to(null)
+        .convertsFrom("")
+        .to(null);
+    assertThat(codec2)
+        .convertsFrom("foo|bar")
+        .to(Sets.newLinkedHashSet(Lists.newArrayList("foo", "bar")))
+        .convertsFrom(" foo | bar ")
+        .to(Sets.newLinkedHashSet(Lists.newArrayList("foo", "bar")))
+        .convertsFrom("|")
+        .to(Sets.newLinkedHashSet(Lists.newArrayList(null, null)))
+        .convertsFrom(null)
+        .to(null)
+        .convertsFrom("")
+        .to(null);
+  }
+
+  @Test
+  public void should_convert_to_valid_input() throws Exception {
+    assertThat(codec1)
+        .convertsTo(Sets.newLinkedHashSet(Lists.newArrayList(1d, 2d, 3d)))
+        .from("1|2|3")
+        .convertsTo(Sets.newLinkedHashSet(Lists.newArrayList(1234.56d, 78900d)))
+        .from("1,234.56|78,900")
+        .convertsTo(Sets.newLinkedHashSet(Lists.newArrayList(1d, null)))
+        .from("1|")
+        .convertsTo(Sets.newLinkedHashSet(Lists.newArrayList(null, 0d)))
+        .from("|0")
+        .convertsTo(Sets.newLinkedHashSet(Lists.newArrayList((Double) null)))
+        .from("")
+        .convertsTo(null)
+        .from(null);
+    assertThat(codec2)
+        .convertsTo(Sets.newLinkedHashSet(Lists.newArrayList("foo", "bar")))
+        .from("foo|bar")
+        .convertsTo(Sets.newLinkedHashSet(Lists.newArrayList((String) null)))
+        .from("")
+        .convertsTo(null)
+        .from(null);
+  }
+
+  @Test
+  public void should_not_convert_from_invalid_input() throws Exception {
+    assertThat(codec1).cannotConvertFrom("1|not a valid double");
+  }
+}

--- a/engine/src/test/java/com/datastax/loader/engine/internal/codecs/StringToTupleCodecTest.java
+++ b/engine/src/test/java/com/datastax/loader/engine/internal/codecs/StringToTupleCodecTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2017 DataStax Inc.
+ *
+ * This software can be used solely with DataStax Enterprise. Please consult the license at
+ * http://www.datastax.com/terms/datastax-dse-driver-license-terms
+ */
+package com.datastax.loader.engine.internal.codecs;
+
+import static com.datastax.driver.core.DataType.timestamp;
+import static com.datastax.driver.core.DataType.varchar;
+import static com.datastax.driver.core.DriverCoreTestHooks.newTupleType;
+import static com.datastax.driver.core.ProtocolVersion.V4;
+import static com.datastax.loader.engine.internal.Assertions.assertThat;
+import static com.datastax.loader.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
+
+import com.datastax.driver.core.CodecRegistry;
+import com.datastax.driver.core.TupleType;
+import com.datastax.driver.core.TypeCodec;
+import com.datastax.driver.extras.codecs.jdk8.InstantCodec;
+import com.google.common.collect.Lists;
+import java.time.Instant;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+public class StringToTupleCodecTest {
+
+  private StringToTupleCodec codec;
+  private TupleType tupleType;
+
+  @Before
+  public void setUp() throws Exception {
+    CodecRegistry codecRegistry = new CodecRegistry().register(InstantCodec.instance);
+    tupleType = newTupleType(V4, codecRegistry, timestamp(), varchar());
+    ConvertingCodec eltCodec1 = new StringToInstantCodec(CQL_DATE_TIME_FORMAT);
+    ConvertingCodec eltCodec2 = new ExtendedCodecRegistry.StringToStringCodec(TypeCodec.varchar());
+    //noinspection unchecked
+    List<ConvertingCodec<String, Object>> eltCodecs = Lists.newArrayList(eltCodec1, eltCodec2);
+    codec = new StringToTupleCodec(TypeCodec.tuple(tupleType), eltCodecs, ",");
+  }
+
+  @Test
+  public void should_convert_from_valid_input() throws Exception {
+    assertThat(codec)
+        .convertsFrom("2016-07-24T20:34:12.999,+01:00")
+        .to(tupleType.newValue(Instant.parse("2016-07-24T20:34:12.999Z"), "+01:00"))
+        .convertsFrom(" 2016-07-24T20:34:12.999 , +01:00 ")
+        .to(tupleType.newValue(Instant.parse("2016-07-24T20:34:12.999Z"), "+01:00"))
+        .convertsFrom("2016-07-24T20:34:12.999Z,+01:00")
+        .to(tupleType.newValue(Instant.parse("2016-07-24T20:34:12.999Z"), "+01:00"))
+        .convertsFrom(",")
+        .to(tupleType.newValue(null, null))
+        .convertsFrom(null)
+        .to(null)
+        .convertsFrom("")
+        .to(null);
+  }
+
+  @Test
+  public void should_convert_to_valid_input() throws Exception {
+    assertThat(codec)
+        .convertsTo(tupleType.newValue(Instant.parse("2016-07-24T20:34:12.999Z"), "+01:00"))
+        .from("2016-07-24T20:34:12.999Z,+01:00")
+        .convertsTo(tupleType.newValue(null, null))
+        .from(",")
+        .convertsTo(null)
+        .from(null);
+  }
+
+  @Test
+  public void should_not_convert_from_invalid_input() throws Exception {
+    assertThat(codec).cannotConvertFrom("not a valid input").cannotConvertFrom("not a,valid input");
+  }
+}

--- a/engine/src/test/java/com/datastax/loader/engine/internal/codecs/StringToUDTCodecTest.java
+++ b/engine/src/test/java/com/datastax/loader/engine/internal/codecs/StringToUDTCodecTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2017 DataStax Inc.
+ *
+ * This software can be used solely with DataStax Enterprise. Please consult the license at
+ * http://www.datastax.com/terms/datastax-dse-driver-license-terms
+ */
+package com.datastax.loader.engine.internal.codecs;
+
+import static com.datastax.driver.core.DataType.cint;
+import static com.datastax.driver.core.DataType.varchar;
+import static com.datastax.driver.core.DriverCoreTestHooks.newField;
+import static com.datastax.driver.core.DriverCoreTestHooks.newUserType;
+import static com.datastax.loader.engine.internal.Assertions.assertThat;
+
+import com.datastax.driver.core.TypeCodec;
+import com.datastax.driver.core.UserType;
+import com.google.common.collect.ImmutableMap;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+
+public class StringToUDTCodecTest {
+
+  private UserType udtType;
+  private StringToUDTCodec codec;
+
+  @Before
+  public void setUp() throws Exception {
+    udtType = newUserType(newField("f1", cint()), newField("f2", varchar()));
+    ConvertingCodec codec1 =
+        new StringToIntegerCodec(
+            ThreadLocal.withInitial(
+                () -> new DecimalFormat("#,###.##", DecimalFormatSymbols.getInstance(Locale.US))));
+    ConvertingCodec codec2 = new ExtendedCodecRegistry.StringToStringCodec(TypeCodec.varchar());
+    //noinspection unchecked
+    Map<String, ConvertingCodec<String, Object>> fieldCodecs =
+        ImmutableMap.of("f1", codec1, "f2", codec2);
+    codec = new StringToUDTCodec(TypeCodec.userType(udtType), fieldCodecs, ",", ":");
+  }
+
+  @Test
+  public void should_convert_from_valid_input() throws Exception {
+    assertThat(codec)
+        .convertsFrom("f1:42,f2:foo")
+        .to(udtType.newValue().setInt("f1", 42).setString("f2", "foo"))
+        .convertsFrom(" f2 : foo , f1 : 42 ")
+        .to(udtType.newValue().setInt("f1", 42).setString("f2", "foo"))
+        .convertsFrom(" f2 :  , f1 :  ")
+        .to(udtType.newValue().setToNull("f1").setToNull("f2"))
+        .convertsFrom(" f1 :  ")
+        .to(udtType.newValue().setToNull("f1").setToNull("f2"))
+        .convertsFrom(null)
+        .to(null)
+        .convertsFrom("")
+        .to(null);
+  }
+
+  @Test
+  public void should_convert_to_valid_input() throws Exception {
+    assertThat(codec)
+        .convertsTo(udtType.newValue().setInt("f1", 42).setString("f2", "foo"))
+        .from("f1:42,f2:foo")
+        .convertsTo(udtType.newValue())
+        .from("f1:,f2:")
+        .convertsTo(null)
+        .from(null);
+  }
+
+  @Test
+  public void should_not_convert_from_invalid_input() throws Exception {
+    assertThat(codec)
+        .cannotConvertFrom("f1:not a valid input , f2:not a valid input")
+        .cannotConvertFrom(":42") // null field name
+        .cannotConvertFrom("not a valid input")
+        .cannotConvertFrom("not a,valid input");
+  }
+}

--- a/engine/src/test/java/com/datastax/loader/engine/internal/settings/CodecSettingsTest.java
+++ b/engine/src/test/java/com/datastax/loader/engine/internal/settings/CodecSettingsTest.java
@@ -6,6 +6,27 @@
  */
 package com.datastax.loader.engine.internal.settings;
 
+import static com.datastax.driver.core.DataType.bigint;
+import static com.datastax.driver.core.DataType.cboolean;
+import static com.datastax.driver.core.DataType.cdouble;
+import static com.datastax.driver.core.DataType.cfloat;
+import static com.datastax.driver.core.DataType.cint;
+import static com.datastax.driver.core.DataType.date;
+import static com.datastax.driver.core.DataType.decimal;
+import static com.datastax.driver.core.DataType.list;
+import static com.datastax.driver.core.DataType.map;
+import static com.datastax.driver.core.DataType.set;
+import static com.datastax.driver.core.DataType.smallint;
+import static com.datastax.driver.core.DataType.time;
+import static com.datastax.driver.core.DataType.timestamp;
+import static com.datastax.driver.core.DataType.timeuuid;
+import static com.datastax.driver.core.DataType.tinyint;
+import static com.datastax.driver.core.DataType.uuid;
+import static com.datastax.driver.core.DataType.varchar;
+import static com.datastax.driver.core.DataType.varint;
+import static com.datastax.driver.core.DriverCoreTestHooks.newField;
+import static com.datastax.driver.core.DriverCoreTestHooks.newTupleType;
+import static com.datastax.driver.core.DriverCoreTestHooks.newUserType;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -13,7 +34,9 @@ import static org.mockito.Mockito.when;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.CodecRegistry;
 import com.datastax.driver.core.Configuration;
-import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.TupleType;
+import com.datastax.driver.core.UserType;
+import com.datastax.loader.engine.internal.codecs.ExtendedCodecRegistry;
 import com.datastax.loader.engine.internal.codecs.NumberToNumberCodec;
 import com.datastax.loader.engine.internal.codecs.StringToBigDecimalCodec;
 import com.datastax.loader.engine.internal.codecs.StringToBigIntegerCodec;
@@ -23,10 +46,15 @@ import com.datastax.loader.engine.internal.codecs.StringToDoubleCodec;
 import com.datastax.loader.engine.internal.codecs.StringToFloatCodec;
 import com.datastax.loader.engine.internal.codecs.StringToInstantCodec;
 import com.datastax.loader.engine.internal.codecs.StringToIntegerCodec;
+import com.datastax.loader.engine.internal.codecs.StringToListCodec;
 import com.datastax.loader.engine.internal.codecs.StringToLocalDateCodec;
 import com.datastax.loader.engine.internal.codecs.StringToLocalTimeCodec;
 import com.datastax.loader.engine.internal.codecs.StringToLongCodec;
+import com.datastax.loader.engine.internal.codecs.StringToMapCodec;
+import com.datastax.loader.engine.internal.codecs.StringToSetCodec;
 import com.datastax.loader.engine.internal.codecs.StringToShortCodec;
+import com.datastax.loader.engine.internal.codecs.StringToTupleCodec;
+import com.datastax.loader.engine.internal.codecs.StringToUDTCodec;
 import com.datastax.loader.engine.internal.codecs.StringToUUIDCodec;
 import com.datastax.loader.engine.internal.codecs.TemporalToTemporalCodec;
 import com.typesafe.config.Config;
@@ -45,121 +73,160 @@ public class CodecSettingsTest {
 
   private Cluster cluster;
 
-  private CodecRegistry codecRegistry;
-
   @Before
   public void setUp() throws Exception {
     cluster = mock(Cluster.class);
-    codecRegistry = new CodecRegistry();
     Configuration configuration = mock(Configuration.class);
     when(cluster.getConfiguration()).thenReturn(configuration);
-    when(configuration.getCodecRegistry()).thenReturn(codecRegistry);
+    when(configuration.getCodecRegistry()).thenReturn(new CodecRegistry());
   }
 
   @Test
-  public void should_register_codecs() throws Exception {
+  public void should_return_string_converting_codecs() throws Exception {
 
     Config config = ConfigFactory.load().getConfig("datastax-loader.codec");
     CodecSettings settings = new CodecSettings(config);
-    settings.init(cluster);
+    ExtendedCodecRegistry codecRegistry = settings.init(cluster);
 
-    assertThat(codecRegistry.codecFor(DataType.cboolean(), String.class))
+    assertThat(codecRegistry.codecFor(cboolean(), String.class))
         .isNotNull()
         .isInstanceOf(StringToBooleanCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.tinyint(), String.class))
+    assertThat(codecRegistry.codecFor(tinyint(), String.class))
         .isNotNull()
         .isInstanceOf(StringToByteCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.smallint(), String.class))
+    assertThat(codecRegistry.codecFor(smallint(), String.class))
         .isNotNull()
         .isInstanceOf(StringToShortCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.cint(), String.class))
+    assertThat(codecRegistry.codecFor(cint(), String.class))
         .isNotNull()
         .isInstanceOf(StringToIntegerCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.bigint(), String.class))
+    assertThat(codecRegistry.codecFor(bigint(), String.class))
         .isNotNull()
         .isInstanceOf(StringToLongCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.cfloat(), String.class))
+    assertThat(codecRegistry.codecFor(cfloat(), String.class))
         .isNotNull()
         .isInstanceOf(StringToFloatCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.cdouble(), String.class))
+    assertThat(codecRegistry.codecFor(cdouble(), String.class))
         .isNotNull()
         .isInstanceOf(StringToDoubleCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.varint(), String.class))
+    assertThat(codecRegistry.codecFor(varint(), String.class))
         .isNotNull()
         .isInstanceOf(StringToBigIntegerCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.decimal(), String.class))
+    assertThat(codecRegistry.codecFor(decimal(), String.class))
         .isNotNull()
         .isInstanceOf(StringToBigDecimalCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.date(), String.class))
+    assertThat(codecRegistry.codecFor(date(), String.class))
         .isNotNull()
         .isInstanceOf(StringToLocalDateCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.time(), String.class))
+    assertThat(codecRegistry.codecFor(time(), String.class))
         .isNotNull()
         .isInstanceOf(StringToLocalTimeCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.timestamp(), String.class))
+    assertThat(codecRegistry.codecFor(timestamp(), String.class))
         .isNotNull()
         .isInstanceOf(StringToInstantCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.uuid(), String.class))
+    assertThat(codecRegistry.codecFor(uuid(), String.class))
         .isNotNull()
         .isInstanceOf(StringToUUIDCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.timeuuid(), String.class))
+    assertThat(codecRegistry.codecFor(timeuuid(), String.class))
         .isNotNull()
         .isInstanceOf(StringToUUIDCodec.class);
+  }
 
-    assertThat(codecRegistry.codecFor(DataType.tinyint(), Short.class))
-        .isNotNull()
-        .isInstanceOf(NumberToNumberCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.smallint(), Integer.class))
-        .isNotNull()
-        .isInstanceOf(NumberToNumberCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.cint(), Long.class))
-        .isNotNull()
-        .isInstanceOf(NumberToNumberCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.bigint(), Float.class))
-        .isNotNull()
-        .isInstanceOf(NumberToNumberCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.cfloat(), Double.class))
-        .isNotNull()
-        .isInstanceOf(NumberToNumberCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.cdouble(), BigDecimal.class))
-        .isNotNull()
-        .isInstanceOf(NumberToNumberCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.varint(), Integer.class))
-        .isNotNull()
-        .isInstanceOf(NumberToNumberCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.decimal(), Float.class))
-        .isNotNull()
-        .isInstanceOf(NumberToNumberCodec.class);
+  @Test
+  public void should_return_number_converting_codecs() throws Exception {
 
-    assertThat(codecRegistry.codecFor(DataType.date(), ZonedDateTime.class))
+    Config config = ConfigFactory.load().getConfig("datastax-loader.codec");
+    CodecSettings settings = new CodecSettings(config);
+    ExtendedCodecRegistry codecRegistry = settings.init(cluster);
+
+    assertThat(codecRegistry.codecFor(tinyint(), Short.class))
+        .isNotNull()
+        .isInstanceOf(NumberToNumberCodec.class);
+    assertThat(codecRegistry.codecFor(smallint(), Integer.class))
+        .isNotNull()
+        .isInstanceOf(NumberToNumberCodec.class);
+    assertThat(codecRegistry.codecFor(cint(), Long.class))
+        .isNotNull()
+        .isInstanceOf(NumberToNumberCodec.class);
+    assertThat(codecRegistry.codecFor(bigint(), Float.class))
+        .isNotNull()
+        .isInstanceOf(NumberToNumberCodec.class);
+    assertThat(codecRegistry.codecFor(cfloat(), Double.class))
+        .isNotNull()
+        .isInstanceOf(NumberToNumberCodec.class);
+    assertThat(codecRegistry.codecFor(cdouble(), BigDecimal.class))
+        .isNotNull()
+        .isInstanceOf(NumberToNumberCodec.class);
+    assertThat(codecRegistry.codecFor(varint(), Integer.class))
+        .isNotNull()
+        .isInstanceOf(NumberToNumberCodec.class);
+    assertThat(codecRegistry.codecFor(decimal(), Float.class))
+        .isNotNull()
+        .isInstanceOf(NumberToNumberCodec.class);
+  }
+
+  @Test
+  public void should_return_temporal_converting_codecs() throws Exception {
+
+    Config config = ConfigFactory.load().getConfig("datastax-loader.codec");
+    CodecSettings settings = new CodecSettings(config);
+    ExtendedCodecRegistry codecRegistry = settings.init(cluster);
+
+    assertThat(codecRegistry.codecFor(date(), ZonedDateTime.class))
         .isNotNull()
         .isInstanceOf(TemporalToTemporalCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.time(), ZonedDateTime.class))
+    assertThat(codecRegistry.codecFor(time(), ZonedDateTime.class))
         .isNotNull()
         .isInstanceOf(TemporalToTemporalCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.timestamp(), ZonedDateTime.class))
+    assertThat(codecRegistry.codecFor(timestamp(), ZonedDateTime.class))
         .isNotNull()
         .isInstanceOf(TemporalToTemporalCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.date(), Instant.class))
+    assertThat(codecRegistry.codecFor(date(), Instant.class))
         .isNotNull()
         .isInstanceOf(TemporalToTemporalCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.time(), Instant.class))
+    assertThat(codecRegistry.codecFor(time(), Instant.class))
         .isNotNull()
         .isInstanceOf(TemporalToTemporalCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.date(), LocalDateTime.class))
+    assertThat(codecRegistry.codecFor(date(), LocalDateTime.class))
         .isNotNull()
         .isInstanceOf(TemporalToTemporalCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.time(), LocalDateTime.class))
+    assertThat(codecRegistry.codecFor(time(), LocalDateTime.class))
         .isNotNull()
         .isInstanceOf(TemporalToTemporalCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.timestamp(), LocalDateTime.class))
+    assertThat(codecRegistry.codecFor(timestamp(), LocalDateTime.class))
         .isNotNull()
         .isInstanceOf(TemporalToTemporalCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.timestamp(), LocalDate.class))
+    assertThat(codecRegistry.codecFor(timestamp(), LocalDate.class))
         .isNotNull()
         .isInstanceOf(TemporalToTemporalCodec.class);
-    assertThat(codecRegistry.codecFor(DataType.timestamp(), LocalTime.class))
+    assertThat(codecRegistry.codecFor(timestamp(), LocalTime.class))
         .isNotNull()
         .isInstanceOf(TemporalToTemporalCodec.class);
+  }
+
+  @Test
+  public void should_return_codecs_for_tokenizable_fields() throws Exception {
+
+    Config config = ConfigFactory.load().getConfig("datastax-loader.codec");
+    CodecSettings settings = new CodecSettings(config);
+    ExtendedCodecRegistry codecRegistry = settings.init(cluster);
+
+    assertThat(codecRegistry.codecFor(list(cint()), String.class))
+        .isNotNull()
+        .isInstanceOf(StringToListCodec.class);
+    assertThat(codecRegistry.codecFor(set(cdouble()), String.class))
+        .isNotNull()
+        .isInstanceOf(StringToSetCodec.class);
+    assertThat(codecRegistry.codecFor(map(time(), varchar()), String.class))
+        .isNotNull()
+        .isInstanceOf(StringToMapCodec.class);
+    TupleType tupleType = newTupleType(cint(), cdouble());
+    assertThat(codecRegistry.codecFor(tupleType, String.class))
+        .isNotNull()
+        .isInstanceOf(StringToTupleCodec.class);
+    UserType udtType = newUserType(newField("f1", cint()), newField("f2", cdouble()));
+    assertThat(codecRegistry.codecFor(udtType, String.class))
+        .isNotNull()
+        .isInstanceOf(StringToUDTCodec.class);
   }
 }

--- a/engine/src/test/java/com/datastax/loader/engine/internal/settings/SchemaSettingsTest.java
+++ b/engine/src/test/java/com/datastax/loader/engine/internal/settings/SchemaSettingsTest.java
@@ -19,12 +19,14 @@ import com.datastax.driver.core.Metadata;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.TableMetadata;
+import com.datastax.loader.engine.internal.codecs.ExtendedCodecRegistry;
 import com.datastax.loader.engine.internal.schema.DefaultMapping;
 import com.datastax.loader.engine.internal.schema.RecordMapper;
 import com.google.common.collect.Lists;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import java.util.List;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -34,6 +36,7 @@ import org.mockito.internal.util.reflection.Whitebox;
 public class SchemaSettingsTest {
 
   private Session session;
+  private ExtendedCodecRegistry codecRegistry = mock(ExtendedCodecRegistry.class);
 
   @Before
   public void setUp() throws Exception {
@@ -60,21 +63,22 @@ public class SchemaSettingsTest {
   public void should_create_mapper_when_mapping_keyspace_and_table_provided() throws Exception {
     Config config =
         ConfigFactory.parseString(
-            "mapping = { 0 = c2 , 2 = c1 }, "
-                + "nullToUnset = true, "
-                + "nullWords = [], "
-                + "keyspace=ks, table=t1")
+                "mapping = { 0 = c2 , 2 = c1 }, "
+                    + "nullToUnset = true, "
+                    + "nullWords = [], "
+                    + "keyspace=ks, table=t1")
             .withFallback(ConfigFactory.load().getConfig("datastax-loader.schema"));
     SchemaSettings schemaSettings = new SchemaSettings(config);
-    RecordMapper recordMapper = schemaSettings.newRecordMapper(session);
+    RecordMapper recordMapper = schemaSettings.init(session, codecRegistry);
     assertThat(recordMapper).isNotNull();
     ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
     verify(session).prepare(argument.capture());
     assertThat(argument.getValue()).isEqualTo("INSERT INTO ks.t1(c2,c1) VALUES (:c2,:c1)");
-    assertThat((DefaultMapping) Whitebox.getInternalState(recordMapper, "mapping"))
-        .containsOnlyKeys(0, 2)
-        .containsValue("c1")
-        .containsValue("c2");
+    DefaultMapping mapping = (DefaultMapping) Whitebox.getInternalState(recordMapper, "mapping");
+    //noinspection unchecked
+    Map<Object, String> fieldsToVariables =
+        (Map<Object, String>) Whitebox.getInternalState(mapping, "fieldsToVariables");
+    assertThat(fieldsToVariables).containsOnlyKeys(0, 2).containsValue("c1").containsValue("c2");
     assertThat((Boolean) Whitebox.getInternalState(recordMapper, "nullToUnset")).isTrue();
     assertThat((List) Whitebox.getInternalState(recordMapper, "nullWords")).isEmpty();
   }
@@ -83,21 +87,22 @@ public class SchemaSettingsTest {
   public void should_create_mapper_when_mapping_and_statement_provided() throws Exception {
     Config config =
         ConfigFactory.parseString(
-            "mapping = { 0 = c2 , 2 = c1 }, "
-                + "nullToUnset = true, "
-                + "nullWords = [], "
-                + "statement=\"insert into ks.table (c1,c2) values (:c1,:c2)\"")
+                "mapping = { 0 = c2 , 2 = c1 }, "
+                    + "nullToUnset = true, "
+                    + "nullWords = [], "
+                    + "statement=\"insert into ks.table (c1,c2) values (:c1,:c2)\"")
             .withFallback(ConfigFactory.load().getConfig("datastax-loader.schema"));
     SchemaSettings schemaSettings = new SchemaSettings(config);
-    RecordMapper recordMapper = schemaSettings.newRecordMapper(session);
+    RecordMapper recordMapper = schemaSettings.init(session, codecRegistry);
     assertThat(recordMapper).isNotNull();
     ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
     verify(session).prepare(argument.capture());
     assertThat(argument.getValue()).isEqualTo("insert into ks.table (c1,c2) values (:c1,:c2)");
-    assertThat((DefaultMapping) Whitebox.getInternalState(recordMapper, "mapping"))
-        .containsOnlyKeys(0, 2)
-        .containsValue("c1")
-        .containsValue("c2");
+    DefaultMapping mapping = (DefaultMapping) Whitebox.getInternalState(recordMapper, "mapping");
+    //noinspection unchecked
+    Map<Object, String> fieldsToVariables =
+        (Map<Object, String>) Whitebox.getInternalState(mapping, "fieldsToVariables");
+    assertThat(fieldsToVariables).containsOnlyKeys(0, 2).containsValue("c1").containsValue("c2");
     assertThat((Boolean) Whitebox.getInternalState(recordMapper, "nullToUnset")).isTrue();
     assertThat((List) Whitebox.getInternalState(recordMapper, "nullWords")).isEmpty();
   }
@@ -106,15 +111,19 @@ public class SchemaSettingsTest {
   public void should_create_mapper_when_keyspace_and_table_provided() throws Exception {
     Config config =
         ConfigFactory.parseString(
-            "nullToUnset = true, " + "nullWords = [], " + "keyspace=ks, table=t1")
+                "nullToUnset = true, " + "nullWords = [], " + "keyspace=ks, table=t1")
             .withFallback(ConfigFactory.load().getConfig("datastax-loader.schema"));
     SchemaSettings schemaSettings = new SchemaSettings(config);
-    RecordMapper recordMapper = schemaSettings.newRecordMapper(session);
+    RecordMapper recordMapper = schemaSettings.init(session, codecRegistry);
     assertThat(recordMapper).isNotNull();
     ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
     verify(session).prepare(argument.capture());
     assertThat(argument.getValue()).isEqualTo("INSERT INTO ks.t1(c1,c2) VALUES (:c1,:c2)");
-    assertThat((DefaultMapping) Whitebox.getInternalState(recordMapper, "mapping"))
+    DefaultMapping mapping = (DefaultMapping) Whitebox.getInternalState(recordMapper, "mapping");
+    //noinspection unchecked
+    Map<Object, String> fieldsToVariables =
+        (Map<Object, String>) Whitebox.getInternalState(mapping, "fieldsToVariables");
+    assertThat(fieldsToVariables)
         .containsOnlyKeys(0, 1, "c1", "c2")
         .containsValue("c1")
         .containsValue("c2");
@@ -126,15 +135,19 @@ public class SchemaSettingsTest {
   public void should_create_mapper_when_null_to_unset_is_false() throws Exception {
     Config config =
         ConfigFactory.parseString(
-            "nullToUnset = false, " + "nullWords = [], " + "keyspace=ks, table=t1")
+                "nullToUnset = false, " + "nullWords = [], " + "keyspace=ks, table=t1")
             .withFallback(ConfigFactory.load().getConfig("datastax-loader.schema"));
     SchemaSettings schemaSettings = new SchemaSettings(config);
-    RecordMapper recordMapper = schemaSettings.newRecordMapper(session);
+    RecordMapper recordMapper = schemaSettings.init(session, codecRegistry);
     assertThat(recordMapper).isNotNull();
     ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
     verify(session).prepare(argument.capture());
     assertThat(argument.getValue()).isEqualTo("INSERT INTO ks.t1(c1,c2) VALUES (:c1,:c2)");
-    assertThat((DefaultMapping) Whitebox.getInternalState(recordMapper, "mapping"))
+    DefaultMapping mapping = (DefaultMapping) Whitebox.getInternalState(recordMapper, "mapping");
+    //noinspection unchecked
+    Map<Object, String> fieldsToVariables =
+        (Map<Object, String>) Whitebox.getInternalState(mapping, "fieldsToVariables");
+    assertThat(fieldsToVariables)
         .containsOnlyKeys(0, 1, "c1", "c2")
         .containsValue("c1")
         .containsValue("c2");
@@ -146,17 +159,21 @@ public class SchemaSettingsTest {
   public void should_create_mapper_when_null_words_are_provided() throws Exception {
     Config config =
         ConfigFactory.parseString(
-            "nullToUnset = false, "
-                + "nullWords = [\"NIL\", \"NULL\"], "
-                + "keyspace=ks, table=t1")
+                "nullToUnset = false, "
+                    + "nullWords = [\"NIL\", \"NULL\"], "
+                    + "keyspace=ks, table=t1")
             .withFallback(ConfigFactory.load().getConfig("datastax-loader.schema"));
     SchemaSettings schemaSettings = new SchemaSettings(config);
-    RecordMapper recordMapper = schemaSettings.newRecordMapper(session);
+    RecordMapper recordMapper = schemaSettings.init(session, codecRegistry);
     assertThat(recordMapper).isNotNull();
     ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
     verify(session).prepare(argument.capture());
     assertThat(argument.getValue()).isEqualTo("INSERT INTO ks.t1(c1,c2) VALUES (:c1,:c2)");
-    assertThat((DefaultMapping) Whitebox.getInternalState(recordMapper, "mapping"))
+    DefaultMapping mapping = (DefaultMapping) Whitebox.getInternalState(recordMapper, "mapping");
+    //noinspection unchecked
+    Map<Object, String> fieldsToVariables =
+        (Map<Object, String>) Whitebox.getInternalState(mapping, "fieldsToVariables");
+    assertThat(fieldsToVariables)
         .containsOnlyKeys(0, 1, "c1", "c2")
         .containsValue("c1")
         .containsValue("c2");

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
     <reactor.version>Aluminium-SR3</reactor.version>
     <config.version>1.3.1</config.version>
     <guava.version>22.0</guava.version>
+    <caffeine.version>2.5.4</caffeine.version>
     <jnr-ffi.version>2.1.6</jnr-ffi.version>
     <slf4j.version>1.7.25</slf4j.version>
     <logback.version>1.2.3</logback.version>
@@ -197,6 +198,12 @@
             <artifactId>j2objc-annotations</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>com.github.ben-manes.caffeine</groupId>
+        <artifactId>caffeine</artifactId>
+        <version>${caffeine.version}</version>
       </dependency>
 
       <dependency>

--- a/tests/src/benchmark/java/com/datastax/loader/executor/api/CSVConnectorBenchmark.java
+++ b/tests/src/benchmark/java/com/datastax/loader/executor/api/CSVConnectorBenchmark.java
@@ -6,6 +6,9 @@
  */
 package com.datastax.loader.executor.api;
 
+import static com.datastax.loader.tests.utils.CsvUtils.createIpByCountryTable;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
 import com.datastax.loader.engine.Main;
@@ -28,9 +31,6 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
-
-import static com.datastax.loader.tests.utils.CsvUtils.createIpByCountryTable;
-import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class CSVConnectorBenchmark {
 
@@ -72,8 +72,8 @@ public class CSVConnectorBenchmark {
       csvFile = dest.resolve("ip-by-country.csv").toUri().toURL();
       cluster.close();
       args = new String[]{
-          "log.outputDirectory=./target",
-          "connector.class=com.datastax.loader.connectors.csv.CSVConnector",
+          "log.outputDirectory=\"file:./target\"",
+          "connector.name=csv",
           "connector.url=\"" + csvFile.toExternalForm() + "\"",
           "schema.keyspace=csv_connector_benchmark",
           "schema.table=ip_by_country"


### PR DESCRIPTION
The mapping of a single record field to a collection, tuple or UDT is based on a very simple tokenization mechanism. 

I didn't deem useful (nor reasonable) to go down the full path of parsing each field as if it were a CSV line of its own, it would make escaping in particular extremely hard to configure.

Also, the handling of nulls is very basic and does not go through the null-words filtering mechanism. Once tokens are obtained, any empty token maps to null.

So it basically boils down to: 

1. a delimiter to tokenize elements;
2. for maps and UDTs, also a key-value separator to split keys and values once elements have been tokenized.

I hope this is enough for now.