### PR TITLE
DAT-59: Windows batch file to launch loader/unloader

### DIFF
--- a/bin/datastax-loader
+++ b/bin/datastax-loader
@@ -15,14 +15,14 @@ Options:
                                    or a prefix of the simple name. Only the built-in
                                    CSVConnector is supported at this time, so "csv"
                                    is a good value for this.
- -s, --connector.common.source <source url or path>
+ -s, --connector.url <source url or path>
                                    Url or file path of data to load; the actual meaning
                                    of this option depends on the selected connector.
  -k, --schema.keyspace <keyspace>  Keyspace into which to load data.
  -t, --schema.table <table>        Table into which to load data.
  -m, --schema.mapping <mapping>    Mapping of fields in data to columns in the database.
 
-All arguments except connector.name and connector.common.source are optional in that
+All arguments except connector.name and connector.url are optional in that
 values fall back to defaults or are inferred from the input data.
 
 
@@ -65,11 +65,11 @@ EXAMPLES:
 
 * Same as last example, but specify a few contact points; note how the value is quoted because
   this setting is an array of strings:
-    $BIN_NAME -c csv -s https://svr/data/export.csv -k ks1 -t table1 -m "{0=col1,1=col3}" --driver.contactPoints '["10.200.1.3","10.200.1.4"]'
+    $BIN_NAME -c csv -s https://svr/data/export.csv -k ks1 -t table1 -m "{0=col1,1=col3}" --driver.contactPoints '["10.200.1.3:9042","10.200.1.4:9042"]'
 
 * Same as last example, but with connector-name, keyspace, table, and mapping set in
   conf/application.conf:
-    $BIN_NAME -s https://svr/data/export.csv --driver.contactPoints '["10.200.1.3","10.200.1.4"]'
+    $BIN_NAME -s https://svr/data/export.csv --driver.contactPoints '["10.200.1.3:9042","10.200.1.4:9042"]'
 END
 }
 
@@ -174,9 +174,11 @@ eval set -- "$PARSERESULT"
 while [ $# -gt 0 ] ; do
   OPT=$(echo $1 | sed -e 's/--//')
   VAL=$2
-  if echo $VAL | grep -E '[#:]' > /dev/null 2>&1 ; then
-    # The value has a special character in it. Quote the value.
-    VAL="\"$VAL\""
+  if ! echo $VAL | grep -E '^[\[{]' > /dev/null 2>&1 ; then
+    if echo $VAL | grep -E '[#:]' > /dev/null 2>&1 ; then
+      # The value has a special character in it. Quote the value.
+      VAL="\"$VAL\""
+    fi
   fi
   if [ -n "$LOADER_CONFIG" ] ; then
     LOADER_CONFIG="$LOADER_CONFIG,"

--- a/bin/datastax-loader.cmd
+++ b/bin/datastax-loader.cmd
@@ -1,0 +1,177 @@
+@ECHO OFF
+SETLOCAL ENABLEDELAYEDEXPANSION
+
+SET ABSOLUTE_BATCH_DIRECTORY=%~DPS0
+SET LOADER_ARGS=
+
+REM First parse command-line args into an option string that the Java tool
+REM can handle.
+REM If the user provided the -h or --help option, emit help and exit.
+REM If parsing fails, exit.
+SET STATE=GETOPT
+FOR %%A IN (%*) DO (
+  call :process_arg %%A
+  IF !ERRORLEVEL! == 2 (
+    REM This means the user asked for usage info.
+    call :usage
+    EXIT /B 0
+  )
+  IF !ERRORLEVEL! == 1 (
+    REM Something went wrong; the callee emitted relevant info. Just exit.
+    EXIT /B 1
+  )
+)
+
+REM LOADER_ARGS starts with a ',' that must be removed.
+SET LOADER_ARGS=!LOADER_ARGS:~1!
+
+REM Set CLASSPATH to include all the jars in the lib directory. Also add
+REM the conf directory, so that application.conf can be found for
+REM permanent overrides.
+
+for %%i in (%ABSOLUTE_BATCH_DIRECTORY%..\lib\*.jar) do call :appendClassPath %%i
+SET CLASSPATH=%ABSOLUTE_BATCH_DIRECTORY%..\conf;!CLASSPATH!
+
+REM Run java from JAVA_HOME, if present, otherwise PATH.
+IF DEFINED JAVA_HOME (
+  SET JAVA=%JAVA_HOME%\bin\java
+) ELSE (
+  SET JAVA=java
+)
+
+REM Run the Java tool.
+"%JAVA%" com.datastax.loader.engine.Main "!LOADER_ARGS!"
+GOTO :eof
+
+REM Helper for adding a particular item to CLASSPATH.
+:appendClassPath
+  SET CLASSPATH=!CLASSPATH!;%1
+  GOTO :eof
+
+REM Logic for parsing one command-line arg (which may be an option or value).
+:process_arg
+  SET PARAM=%~1
+  IF !STATE! == GETOPT (
+    SET OPT_NAME=
+    IF "!PARAM:~0,2!" == "--" (
+      REM This is a long option.
+      REM Strip off the leading --
+      SET OPT_NAME=%PARAM:~2%
+    ) ELSE (
+      IF "!PARAM:~0,1!" == "-" (
+        REM This is a short option.
+        IF "!PARAM!" == "-h" SET OPT_NAME=help
+        IF "!PARAM!" == "-c" SET OPT_NAME=connector.name
+        IF "!PARAM!" == "-s" SET OPT_NAME=connector.url
+        IF "!PARAM!" == "-k" SET OPT_NAME=schema.keyspace
+        IF "!PARAM!" == "-t" SET OPT_NAME=schema.table
+        IF "!PARAM!" == "-m" SET OPT_NAME=schema.mapping
+      )
+    )
+    IF NOT DEFINED OPT_NAME (
+      REM Illegal arg
+      call :usage
+      ECHO.
+      ECHO Unrecognized option !PARAM!
+      EXIT /B 1
+    )
+    IF "!OPT_NAME!" == "help" (
+      EXIT /B 2
+    )
+    
+    REM Tack on the new option to LOADER_ARGS.
+    SET LOADER_ARGS=!LOADER_ARGS!,!OPT_NAME!=
+    SET STATE=GETVAL
+    GOTO :eof
+  ) ELSE (
+    REM This is a value. If it contains a #, quote the value.
+    IF NOT "!PARAM:#=!" == "!PARAM!" (
+      SET PARAM=""!PARAM!""
+    ) ELSE (
+      REM If it contains a :, quote the value, but only if the setting 
+      REM is not a map or array (e.g. beginning with { or [).
+      IF NOT "!PARAM:~0,1!" == "[" (
+        IF NOT "!PARAM:~0,1!" == "{" (
+          IF NOT "!PARAM::=!" == "!PARAM!" (
+            SET PARAM=""!PARAM!""
+          )
+        )
+      )
+    )
+
+    REM Replace \ with /.
+    set PARAM=!PARAM:\=/!
+
+    REM Finally, append the value to our collection of args.
+    SET LOADER_ARGS=!LOADER_ARGS!!PARAM!
+    SET STATE=GETOPT
+  )
+  GOTO :eof
+ 
+REM Simple subroutine to emit usage text.
+:usage
+  SET BATCH_FILENAME=%~N0%
+  ECHO Usage: !BATCH_FILENAME! ^<options^>
+  ECHO Options:
+  ECHO  -c, --connector.name ^<name^>       Name of connector; may be the fqcn or simple name
+  ECHO                                    of an implementation of the Connector interface,
+  ECHO                                    or a prefix of the simple name. Only the built-in
+  ECHO                                    CSVConnector is supported at this time, so "csv"
+  ECHO                                    is a good value for this.
+  ECHO  -s, --connector.url ^<source url or path^>
+  ECHO                                    Url or file path of data to load.
+  ECHO  -k, --schema.keyspace ^<keyspace^>  Keyspace into which to load data.
+  ECHO  -t, --schema.table ^<table^>        Table into which to load data.
+  ECHO  -m, --schema.mapping ^<mapping^>    Mapping of fields in data to columns in the database.
+  ECHO.
+  ECHO All arguments except connector.name and connector.url are optional in that
+  ECHO values fall back to defaults or are inferred from the input data.
+  ECHO.
+  ECHO.
+  ECHO CONFIG FILES, SETTINGS SEARCH ORDER, AND OVERRIDES:
+  ECHO.
+  ECHO Available settings along with defaults are recorded in conf/reference.conf. This file
+  ECHO also contains detailed descriptions of settings and is a great source of information.
+  ECHO When the loader starts up, settings are first loaded from conf/reference.conf.
+  ECHO.
+  ECHO The conf directory also contains an application.conf where a user may specify permanent
+  ECHO overrides of settings. These may be in nested-structure form like this:
+  ECHO.
+  ECHO datastax-loader {
+  ECHO   connector {
+  ECHO     name="csv"
+  ECHO   }
+  ECHO }
+  ECHO.
+  ECHO or dotted form: datastax-loader.connector.name="csv"
+  ECHO.
+  ECHO Finally, a user may specify impromptu overrides via long options on the command line.
+  ECHO See examples for details.
+  ECHO.
+  ECHO.
+  ECHO EXAMPLES:
+  ECHO * Load CSV data from stdin to the ks1.table1 table in a cluster with
+  ECHO   a localhost contact point. Field names in the data match column names in the
+  ECHO   table. Field names are obtained from a "header row" in the data:
+  ECHO     generate_data ^| !BATCH_FILENAME! -c csv -s stdin:/ -k ks1 -t table1 --connector.csv.header=true
+  ECHO.
+  ECHO * Same as last example, but load from a local file:
+  ECHO     !BATCH_FILENAME! -c csv -s C:\data\export.csv -k ks1 -t table1 --connector.csv.header=true
+  ECHO.
+  ECHO * Same as last example, but load data from a url:
+  ECHO     !BATCH_FILENAME! -c csv -s https://svr/data/export.csv -k ks1 -t table1 --connector.csv.header=true
+  ECHO.
+  ECHO * Same as last example, but there is no header row and we specify an explicit field mapping based
+  ECHO   on field indices in the input:
+  ECHO     !BATCH_FILENAME! -c csv -s https://svr/data/export.csv -k ks1 -t table1 -m "{0=col1,1=col3}"
+  ECHO.
+  ECHO * Same as last example, but specify a few contact points; note how the value is quoted:
+  ECHO     !BATCH_FILENAME! -c csv -s https://svr/data/export.csv -k ks1 -t table1 -m "{0=col1,1=col3}" --driver.contactPoints [""10.200.1.3:9042"",""10.200.1.4:9042""]
+  ECHO.
+  ECHO * Same as last example, but with connector-name, keyspace, table, and mapping set in
+  ECHO   conf/application.conf:
+  ECHO     !BATCH_FILENAME! -s https://svr/data/export.csv --driver.contactPoints [""10.200.1.3:9042"",""10.200.1.4:9042""]
+
+  GOTO :eof
+
+ENDLOCAL

--- a/engine/src/test/java/com/datastax/loader/engine/MainTest.java
+++ b/engine/src/test/java/com/datastax/loader/engine/MainTest.java
@@ -22,7 +22,7 @@ public class MainTest {
     create table ks.t1 (Year int primary key,Make varchar,Model varchar,Description varchar,Price decimal);
      */
     String[] args = {
-      "log.outputDirectory=\"file:./target\"",
+      "log.outputDirectory=\"./target\"",
       "connector.name=csv",
       "connector.url=\"" + MainTest.class.getResource("/good.csv").toExternalForm() + "\"",
       "connector.comment=\"#\"",


### PR DESCRIPTION
* Also fix defect in Unix script to *not* quote values that
  are maps or lists even if they contain special characters.