### PR TITLE
DAT-60: driver.contactPoints should support hostnames/ip's without ports

### DIFF
--- a/bin/datastax-loader
+++ b/bin/datastax-loader
@@ -60,12 +60,15 @@ EXAMPLES:
   on field indices in the input:
     $BIN_NAME -c csv --connector.csv.url https://svr/data/export.csv -k ks1 -t table1 -m "{0=col1,1=col3}"
 
-* Same as last example, but specify a few contact points; note how the value is quoted:
-    $BIN_NAME -c csv --connector.csv.url https://svr/data/export.csv -k ks1 -t table1 -m "{0=col1,1=col3}" --driver.contactPoints '["10.200.1.3:9042","10.200.1.4:9042"]'
+* Same as last example, but specify a few contact points at the default port:
+    $BIN_NAME -c csv --connector.csv.url https://svr/data/export.csv -k ks1 -t table1 -m "{0=col1,1=col3}" --driver.contactPoints '[10.200.1.3, 10.200.1.4]'
 
-* Same as last example, but with connector-name, keyspace, table, and mapping set in
+* Same as last example, but specify port 9876 for the contact points:
+    $BIN_NAME -c csv --connector.csv.url https://svr/data/export.csv -k ks1 -t table1 -m "{0=col1,1=col3}" --driver.contactPoints '[10.200.1.3, 10.200.1.4]' --driver.port 9876
+
+* Same as last example, but with default port for contact points, and connector-name, keyspace, table, and mapping set in
   conf/application.conf:
-    $BIN_NAME --connector.csv.url https://svr/data/export.csv --driver.contactPoints '["10.200.1.3:9042","10.200.1.4:9042"]'
+    $BIN_NAME --connector.csv.url https://svr/data/export.csv --driver.contactPoints '[10.200.1.3, 10.200.1.4]'
 END
 }
 

--- a/bin/datastax-loader.cmd
+++ b/bin/datastax-loader.cmd
@@ -161,12 +161,15 @@ REM Simple subroutine to emit usage text.
   ECHO   on field indices in the input:
   ECHO     !BATCH_FILENAME! -c csv --connector.csv.url https://svr/data/export.csv -k ks1 -t table1 -m "{0=col1,1=col3}"
   ECHO.
-  ECHO * Same as last example, but specify a few contact points; note how the value is quoted:
-  ECHO     !BATCH_FILENAME! -c csv --connector.csv.url https://svr/data/export.csv -k ks1 -t table1 -m "{0=col1,1=col3}" --driver.contactPoints "[""10.200.1.3:9042"",""10.200.1.4:9042""]"
+  ECHO * Same as last example, but specify a few contact points at the default port:
+  ECHO     !BATCH_FILENAME! -c csv --connector.csv.url https://svr/data/export.csv -k ks1 -t table1 -m "{0=col1,1=col3}" --driver.contactPoints "[10.200.1.3, 10.200.1.4]"
   ECHO.
-  ECHO * Same as last example, but with connector-name, keyspace, table, and mapping set in
+  ECHO * Same as last example, but specify port 9876 for the contact points:
+  ECHO     !BATCH_FILENAME! -c csv --connector.csv.url https://svr/data/export.csv -k ks1 -t table1 -m "{0=col1,1=col3}" --driver.contactPoints "[10.200.1.3, 10.200.1.4]" --driver.port 9876
+  ECHO.
+  ECHO * Same as last example, but with default port for contact points, and connector-name, keyspace, table, and mapping set in
   ECHO   conf/application.conf:
-  ECHO     !BATCH_FILENAME! --connector.csv.url https://svr/data/export.csv --driver.contactPoints "[""10.200.1.3:9042"",""10.200.1.4:9042""]"
+  ECHO     !BATCH_FILENAME! --connector.csv.url https://svr/data/export.csv --driver.contactPoints "[10.200.1.3, 10.200.1.4]"
 
   GOTO :eof
 

--- a/connectors/csv/src/main/java/com/datastax/loader/connectors/csv/CSVConnector.java
+++ b/connectors/csv/src/main/java/com/datastax/loader/connectors/csv/CSVConnector.java
@@ -6,6 +6,9 @@
  */
 package com.datastax.loader.connectors.csv;
 
+import static java.nio.file.FileVisitResult.CONTINUE;
+import static java.nio.file.FileVisitResult.TERMINATE;
+
 import com.datastax.loader.commons.config.LoaderConfig;
 import com.datastax.loader.connectors.api.Connector;
 import com.datastax.loader.connectors.api.Record;
@@ -17,10 +20,6 @@ import com.univocity.parsers.csv.CsvParserSettings;
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
 import io.reactivex.schedulers.Schedulers;
-import org.reactivestreams.Publisher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -37,9 +36,9 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collections;
-
-import static java.nio.file.FileVisitResult.CONTINUE;
-import static java.nio.file.FileVisitResult.TERMINATE;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A connector for CSV files.

--- a/engine/src/main/java/com/datastax/loader/engine/internal/settings/DriverSettings.java
+++ b/engine/src/main/java/com/datastax/loader/engine/internal/settings/DriverSettings.java
@@ -65,13 +65,14 @@ public class DriverSettings {
 
   public DseCluster newCluster() throws Exception {
     DseCluster.Builder builder = DseCluster.builder().withClusterName(operationId + "-driver");
+    int defaultPort = config.getInt("port");
     config
         .getStringList("contactPoints")
         .forEach(
             s -> {
               String[] tokens = s.split(":");
-              builder.addContactPointsWithPorts(
-                  new InetSocketAddress(tokens[0], Integer.parseInt(tokens[1])));
+              int port = tokens.length > 1 ? Integer.parseInt(tokens[1]) : defaultPort;
+              builder.addContactPointsWithPorts(new InetSocketAddress(tokens[0], port));
             });
 
     ProtocolVersion protocolVersion;

--- a/engine/src/main/resources/reference.conf
+++ b/engine/src/main/resources/reference.conf
@@ -10,13 +10,17 @@ datastax-loader {
   driver {
 
     # The contact points to use for the initial connection to the cluster.
-    # This must be a list of strings with each contact point specified as "host:port". If the host is
+    # This must be a list of strings with each contact point's host-name or ip address. If the host is
     # a DNS name that resolves to multiple A-records, all the corresponding addresses will be used.
     # Do not use "localhost" as the host name (since it resolves to both IPv4 and IPv6 addresses on
     # some platforms).
+    # Defaults to ["127.0.0.1"].
+    contactPoints = ["127.0.0.1"]
+
+    # The port to connect to on contact points.
     # Note that all nodes in a cluster must share the same port.
-    # Defaults to ["127.0.0.1:9042"].
-    contactPoints = ["127.0.0.1:9042"]
+    # Defaults to 9042.
+    port = 9042
 
     # Native Protocol-specific settings.
     protocol {

--- a/engine/src/test/java/com/datastax/loader/engine/MainTest.java
+++ b/engine/src/test/java/com/datastax/loader/engine/MainTest.java
@@ -24,7 +24,7 @@ public class MainTest {
     String[] args = {
       "log.outputDirectory=\"./target\"",
       "connector.name=csv",
-      "connector.url=\"" + MainTest.class.getResource("/good.csv").toExternalForm() + "\"",
+      "connector.csv.url=\"" + MainTest.class.getResource("/good.csv").toExternalForm() + "\"",
       "connector.comment=\"#\"",
       "connector.header=true",
       "driver.query.consistency=ONE",

--- a/engine/src/test/java/com/datastax/loader/engine/internal/settings/ConnectorSettingsTest.java
+++ b/engine/src/test/java/com/datastax/loader/engine/internal/settings/ConnectorSettingsTest.java
@@ -6,6 +6,8 @@
  */
 package com.datastax.loader.engine.internal.settings;
 
+import static com.datastax.loader.engine.internal.Assertions.assertThat;
+
 import com.datastax.loader.commons.config.DefaultLoaderConfig;
 import com.datastax.loader.commons.config.LoaderConfig;
 import com.datastax.loader.connectors.api.Connector;
@@ -17,9 +19,6 @@ import com.typesafe.config.ConfigValue;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import static com.datastax.loader.engine.internal.Assertions.assertThat;
-
 
 public class ConnectorSettingsTest {
   private static final Config CONNECTOR_DEFAULT_SETTINGS =

--- a/engine/src/test/java/com/datastax/loader/engine/internal/settings/DriverSettingsTest.java
+++ b/engine/src/test/java/com/datastax/loader/engine/internal/settings/DriverSettingsTest.java
@@ -61,7 +61,8 @@ public class DriverSettingsTest {
     LoaderConfig config =
         new DefaultLoaderConfig(
             new DefaultLoaderConfig(
-                ConfigFactory.parseString("contactPoints = [ \"1.2.3.4:9042\", \"2.3.4.5:9042\" ]")
+                ConfigFactory.parseString(
+                        "port = 9876, contactPoints = [ \"1.2.3.4:9042\", \"2.3.4.5\" ]")
                     .withFallback(ConfigFactory.load().getConfig("datastax-loader.driver"))));
     DriverSettings driverSettings = new DriverSettings(config, "test");
     DseCluster cluster = driverSettings.newCluster();
@@ -73,7 +74,7 @@ public class DriverSettingsTest {
         (List<InetSocketAddress>) Whitebox.getInternalState(manager, "contactPoints");
     assertThat(contactPoints)
         .containsExactly(
-            new InetSocketAddress("1.2.3.4", 9042), new InetSocketAddress("2.3.4.5", 9042));
+            new InetSocketAddress("1.2.3.4", 9042), new InetSocketAddress("2.3.4.5", 9876));
     DseConfiguration configuration = cluster.getConfiguration();
     assertThat(
             Whitebox.getInternalState(configuration.getProtocolOptions(), "initialProtocolVersion"))

--- a/manual/README.md
+++ b/manual/README.md
@@ -70,10 +70,13 @@ EXAMPLES:
   on field indices in the input:
     datastax-loader -c csv --connector.csv.url https://svr/data/export.csv -k ks1 -t table1 -m "{0=col1,1=col3}"
 
-* Same as last example, but specify a few contact points; note how the value is quoted:
-    datastax-loader -c csv --connector.csv.url https://svr/data/export.csv -k ks1 -t table1 -m "{0=col1,1=col3}" --driver.contactPoints '["10.200.1.3:9042","10.200.1.4:9042"]'
+* Same as last example, but specify a few contact points at the default port:
+    datastax-loader -c csv --connector.csv.url https://svr/data/export.csv -k ks1 -t table1 -m "{0=col1,1=col3}" --driver.contactPoints '[10.200.1.3, 10.200.1.4]'
 
-* Same as last example, but with connector-name, keyspace, table, and mapping set in
+* Same as last example, but specify port 9876 for the contact points:
+    datastax-loader -c csv --connector.csv.url https://svr/data/export.csv -k ks1 -t table1 -m "{0=col1,1=col3}" --driver.contactPoints '[10.200.1.3, 10.200.1.4]' --driver.port 9876
+
+* Same as last example, but with default port for contact points, and connector-name, keyspace, table, and mapping set in
   conf/application.conf:
-    datastax-loader --connector.csv.url https://svr/data/export.csv --driver.contactPoints '["10.200.1.3:9042","10.200.1.4:9042"]'
+    datastax-loader --connector.csv.url https://svr/data/export.csv --driver.contactPoints '[10.200.1.3, 10.200.1.4]'
 ```

--- a/manual/engine/configuration/README.md
+++ b/manual/engine/configuration/README.md
@@ -30,13 +30,18 @@ The following options can be configured:
  
     * `contactPoints` [string list]
     
-         The contact points to use for the initial connection to the cluster
-         This must be a list of strings with each contact point specified as "host:port". If the host is
+         The contact points to use for the initial connection to the cluster.
+         This must be a list of strings with each contact point's host-name or ip address. If the host is
          a DNS name that resolves to multiple A-records, all the corresponding addresses will be used.
          Do not use "localhost" as the host name (since it resolves to both IPv4 and IPv6 addresses on
          some platforms).
+         Defaults to `["127.0.0.1"]`.
+
+    * `port` [int]
+
+         The port to connect to on contact points.
          Note that all nodes in a cluster must share the same port.
-         Defaults to `["127.0.0.1:9042"]`.
+         Defaults to 9042.
 
     * `protocol`
     


### PR DESCRIPTION
* Add driver.port setting with default value 9042.
* Update DriverSettings to use the `port` setting for contact points
  when the contactPoints list doesn't include ports.