### PR TITLE
DAT-26

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2,6 +2,9 @@ schedules:
   commit:
     # Run short suite on commit
     schedule: per_commit
+    matrix:
+      exclude:
+        - cassandra: ['dse-4.8', 'dse-5.0']
   nightly:
     # Run full suite nightly on change for all primary branches if they have changes.
     schedule: nightly
@@ -24,7 +27,7 @@ cassandra:
 build:
   - type: maven
     version: 3.2.5
-    goals: verify --fail-never
+    goals: verify -Plong -fae
     properties: |
       com.datastax.loader.tests.ccm.JAVA_HOME=$CCM_JAVA_HOME
       com.datastax.loader.tests.ccm.PATH=$CCM_JAVA_HOME/bin

--- a/pom.xml
+++ b/pom.xml
@@ -360,52 +360,12 @@
               </goals>
             </execution>
           </executions>
-          <configuration>
-            <additionalSourceDirectories>
-              <additionalSourceDirectory>src/it/java</additionalSourceDirectory>
-              <additionalSourceDirectory>src/benchmark/java</additionalSourceDirectory>
-            </additionalSourceDirectories>
-          </configuration>
         </plugin>
 
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
           <version>3.0.0</version>
-          <executions>
-            <execution>
-              <id>add-integration-test-sources</id>
-              <phase>generate-test-sources</phase>
-              <goals>
-                <goal>add-test-source</goal>
-              </goals>
-              <configuration>
-                <sources>
-                  <source>src/it/java</source>
-                  <source>src/benchmark/java</source>
-                </sources>
-              </configuration>
-            </execution>
-            <execution>
-              <id>add-integration-test-resources</id>
-              <phase>generate-test-resources</phase>
-              <goals>
-                <goal>add-test-resource</goal>
-              </goals>
-              <configuration>
-                <resources>
-                  <resource>
-                    <filtering>false</filtering>
-                    <directory>src/it/resources</directory>
-                  </resource>
-                  <resource>
-                    <filtering>false</filtering>
-                    <directory>src/benchmark/resources</directory>
-                  </resource>
-                </resources>
-              </configuration>
-            </execution>
-          </executions>
         </plugin>
 
         <plugin>
@@ -486,14 +446,6 @@ http://www.datastax.com/terms/datastax-dse-driver-license-terms
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>2.20</version>
-          <executions>
-            <execution>
-              <goals>
-                <goal>integration-test</goal>
-                <goal>verify</goal>
-              </goals>
-            </execution>
-          </executions>
         </plugin>
 
         <plugin>
@@ -635,11 +587,6 @@ http://www.datastax.com/terms/datastax-dse-driver-license-terms
       <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
-      </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
       </plugin>
 
       <plugin>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -148,7 +148,75 @@
     <plugins>
 
       <plugin>
+        <groupId>com.coveo</groupId>
+        <artifactId>fmt-maven-plugin</artifactId>
+        <configuration>
+          <additionalSourceDirectories>
+            <additionalSourceDirectory>src/it/java</additionalSourceDirectory>
+            <additionalSourceDirectory>src/benchmark/java</additionalSourceDirectory>
+          </additionalSourceDirectories>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-integration-test-sources</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>src/it/java</source>
+                <source>src/benchmark/java</source>
+              </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-integration-test-resources</id>
+            <phase>generate-test-resources</phase>
+            <goals>
+              <goal>add-test-resource</goal>
+            </goals>
+            <configuration>
+              <resources>
+                <resource>
+                  <filtering>false</filtering>
+                  <directory>src/it/resources</directory>
+                </resource>
+                <resource>
+                  <filtering>false</filtering>
+                  <directory>src/benchmark/resources</directory>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>short-tests</id>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <!-- skip long tests by default -->
+              <excludedGroups>
+                com.datastax.loader.tests.categories.LongTests
+              </excludedGroups>
+              <reportNameSuffix>short</reportNameSuffix>
+              <!-- set so test can exit with rc 0 (ci will mark test failures accordingly) -->
+            </configuration>
+          </execution>
+        </executions>
+
       </plugin>
 
       <plugin>
@@ -196,5 +264,34 @@
     </plugins>
 
   </build>
-  
+
+  <profiles>
+
+    <profile>
+      <id>long</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <executions>
+              <!-- add a special execution that only runs long tests -->
+              <execution>
+                <id>long-tests</id>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <groups>com.datastax.loader.tests.categories.LongTests</groups>
+                  <reportNameSuffix>long</reportNameSuffix>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+  </profiles>
+
 </project>

--- a/tests/src/it/java/com/datastax/loader/engine/simulacron/CSVWriteEndToEndIT.java
+++ b/tests/src/it/java/com/datastax/loader/engine/simulacron/CSVWriteEndToEndIT.java
@@ -67,7 +67,7 @@ public class CSVWriteEndToEndIT {
   public void full_load_crlf() throws Exception {
 
     String[] args = {
-      "log.output-directory=\"file:./target\"",
+      "log.outputDirectory=./target",
       "connector.name=csv",
       "connector.csv.url=\"" + CsvUtils.CSV_RECORDS_CRLF.toExternalForm() + "\"",
       "driver.query.consistency=ONE",

--- a/tests/src/it/java/com/datastax/loader/executor/api/ccm/ContinuousReactorBulkExecutorIT.java
+++ b/tests/src/it/java/com/datastax/loader/executor/api/ccm/ContinuousReactorBulkExecutorIT.java
@@ -7,10 +7,13 @@
 package com.datastax.loader.executor.api.ccm;
 
 import com.datastax.loader.executor.api.ContinuousReactorBulkExecutor;
+import com.datastax.loader.tests.categories.LongTests;
 import com.datastax.loader.tests.ccm.annotations.CCMTest;
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
 @CCMTest
+@Category(LongTests.class)
 public class ContinuousReactorBulkExecutorIT extends AbstractContinuousBulkExecutorIT {
 
   @BeforeClass

--- a/tests/src/it/java/com/datastax/loader/executor/api/ccm/ContinuousRxJavaBulkExecutorIT.java
+++ b/tests/src/it/java/com/datastax/loader/executor/api/ccm/ContinuousRxJavaBulkExecutorIT.java
@@ -7,10 +7,13 @@
 package com.datastax.loader.executor.api.ccm;
 
 import com.datastax.loader.executor.api.ContinuousRxJavaBulkExecutor;
+import com.datastax.loader.tests.categories.LongTests;
 import com.datastax.loader.tests.ccm.annotations.CCMTest;
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
 @CCMTest
+@Category(LongTests.class)
 public class ContinuousRxJavaBulkExecutorIT extends AbstractContinuousBulkExecutorIT {
 
   @BeforeClass

--- a/tests/src/it/java/com/datastax/loader/executor/api/ccm/DefaultReactorBulkExecutorIT.java
+++ b/tests/src/it/java/com/datastax/loader/executor/api/ccm/DefaultReactorBulkExecutorIT.java
@@ -7,10 +7,13 @@
 package com.datastax.loader.executor.api.ccm;
 
 import com.datastax.loader.executor.api.DefaultReactorBulkExecutor;
+import com.datastax.loader.tests.categories.LongTests;
 import com.datastax.loader.tests.ccm.annotations.CCMTest;
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
 @CCMTest
+@Category(LongTests.class)
 public class DefaultReactorBulkExecutorIT extends AbstractBulkExecutorIT {
 
   @BeforeClass

--- a/tests/src/it/java/com/datastax/loader/executor/api/ccm/DefaultRxJavaBulkExecutorIT.java
+++ b/tests/src/it/java/com/datastax/loader/executor/api/ccm/DefaultRxJavaBulkExecutorIT.java
@@ -7,10 +7,13 @@
 package com.datastax.loader.executor.api.ccm;
 
 import com.datastax.loader.executor.api.DefaultRxJavaBulkExecutor;
+import com.datastax.loader.tests.categories.LongTests;
 import com.datastax.loader.tests.ccm.annotations.CCMTest;
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
 @CCMTest
+@Category(LongTests.class)
 public class DefaultRxJavaBulkExecutorIT extends AbstractBulkExecutorIT {
 
   @BeforeClass

--- a/tests/src/it/java/com/datastax/loader/executor/api/ccm/ReactorReadWriteIT.java
+++ b/tests/src/it/java/com/datastax/loader/executor/api/ccm/ReactorReadWriteIT.java
@@ -10,9 +10,12 @@ import com.datastax.driver.core.Session;
 import com.datastax.loader.executor.api.BulkExecutor;
 import com.datastax.loader.executor.api.DefaultReactorBulkExecutor;
 import com.datastax.loader.executor.api.listener.ExecutionListener;
+import com.datastax.loader.tests.categories.LongTests;
 import com.datastax.loader.tests.ccm.annotations.CCMTest;
+import org.junit.experimental.categories.Category;
 
 @CCMTest
+@Category(LongTests.class)
 public class ReactorReadWriteIT extends AbstractReadWriteIT {
 
   protected BulkExecutor getBulkExecutor(ExecutionListener listener, Session session) {

--- a/tests/src/it/java/com/datastax/loader/executor/api/ccm/RxJavaReadWriteIT.java
+++ b/tests/src/it/java/com/datastax/loader/executor/api/ccm/RxJavaReadWriteIT.java
@@ -10,9 +10,12 @@ import com.datastax.driver.core.Session;
 import com.datastax.loader.executor.api.BulkExecutor;
 import com.datastax.loader.executor.api.DefaultRxJavaBulkExecutor;
 import com.datastax.loader.executor.api.listener.ExecutionListener;
+import com.datastax.loader.tests.categories.LongTests;
 import com.datastax.loader.tests.ccm.annotations.CCMTest;
+import org.junit.experimental.categories.Category;
 
 @CCMTest
+@Category(LongTests.class)
 public class RxJavaReadWriteIT extends AbstractReadWriteIT {
 
   protected BulkExecutor getBulkExecutor(ExecutionListener listener, Session session) {

--- a/tests/src/it/java/com/datastax/loader/executor/api/statement/TableScannerIT.java
+++ b/tests/src/it/java/com/datastax/loader/executor/api/statement/TableScannerIT.java
@@ -12,6 +12,7 @@ import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Metadata;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.Statement;
+import com.datastax.loader.tests.categories.LongTests;
 import com.datastax.loader.tests.ccm.CCMRule;
 import com.datastax.loader.tests.ccm.annotations.CCMConfig;
 import com.datastax.loader.tests.ccm.annotations.CCMTest;
@@ -21,9 +22,11 @@ import java.util.List;
 import javax.inject.Inject;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 @CCMTest
 @CCMConfig(numberOfNodes = 3)
+@Category(LongTests.class)
 public class TableScannerIT {
 
   @ClassRule public static CCMRule ccmRule = new CCMRule();

--- a/tests/src/test/java/com/datastax/loader/tests/categories/LongTests.java
+++ b/tests/src/test/java/com/datastax/loader/tests/categories/LongTests.java
@@ -1,0 +1,10 @@
+package com.datastax.loader.tests.categories;
+/*
+ * Copyright (C) 2017 DataStax Inc.
+ *
+ * This software can be used solely with DataStax Enterprise. Please consult the license at
+ * http://www.datastax.com/terms/datastax-dse-driver-license-terms
+ */
+
+/** Defines a classification of tests that are slow. */
+public interface LongTests {}


### PR DESCRIPTION

Default configuration for testing will now run everything but the CCM tests.

Currently CCM tests will still run on Jenkins a per commit basis, as our configurations/number of tests increase we can revisit that, but as of right now the job time is still right around 5 minutes which is acceptable.

Also Fixed up an issue with the CSVWriteEndToEndIT.java which was broken due to changes in 1.x