### PR TITLE
DAT-101: Fix flaky CCM tests

### DIFF
--- a/tests/src/it/java/com/datastax/dsbulk/executor/api/ccm/ContinuousReactorBulkExecutorIT.java
+++ b/tests/src/it/java/com/datastax/dsbulk/executor/api/ccm/ContinuousReactorBulkExecutorIT.java
@@ -18,7 +18,11 @@ public class ContinuousReactorBulkExecutorIT extends AbstractContinuousBulkExecu
 
   @BeforeClass
   public static void createBulkExecutors() {
-    failFastExecutor = ContinuousReactorBulkExecutor.builder(session).build();
+    failFastExecutor =
+        ContinuousReactorBulkExecutor.builder(session)
+            // serialize execution of statements to force results to be produced in deterministic order
+            .withMaxInFlightRequests(1)
+            .build();
     failSafeExecutor = ContinuousReactorBulkExecutor.builder(session).failSafe().build();
   }
 }

--- a/tests/src/it/java/com/datastax/dsbulk/executor/api/ccm/ContinuousRxJavaBulkExecutorIT.java
+++ b/tests/src/it/java/com/datastax/dsbulk/executor/api/ccm/ContinuousRxJavaBulkExecutorIT.java
@@ -18,7 +18,11 @@ public class ContinuousRxJavaBulkExecutorIT extends AbstractContinuousBulkExecut
 
   @BeforeClass
   public static void createBulkExecutors() {
-    failFastExecutor = ContinuousRxJavaBulkExecutor.builder(session).build();
+    failFastExecutor =
+        ContinuousRxJavaBulkExecutor.builder(session)
+            // serialize execution of statements to force results to be produced in deterministic order
+            .withMaxInFlightRequests(1)
+            .build();
     failSafeExecutor = ContinuousRxJavaBulkExecutor.builder(session).failSafe().build();
   }
 }

--- a/tests/src/it/java/com/datastax/dsbulk/executor/api/ccm/DefaultReactorBulkExecutorIT.java
+++ b/tests/src/it/java/com/datastax/dsbulk/executor/api/ccm/DefaultReactorBulkExecutorIT.java
@@ -18,7 +18,11 @@ public class DefaultReactorBulkExecutorIT extends AbstractBulkExecutorIT {
 
   @BeforeClass
   public static void createBulkExecutors() {
-    failFastExecutor = DefaultReactorBulkExecutor.builder(session).build();
+    failFastExecutor =
+        DefaultReactorBulkExecutor.builder(session)
+            // serialize execution of statements to force results to be produced in deterministic order
+            .withMaxInFlightRequests(1)
+            .build();
     failSafeExecutor = DefaultReactorBulkExecutor.builder(session).failSafe().build();
   }
 }

--- a/tests/src/it/java/com/datastax/dsbulk/executor/api/ccm/DefaultRxJavaBulkExecutorIT.java
+++ b/tests/src/it/java/com/datastax/dsbulk/executor/api/ccm/DefaultRxJavaBulkExecutorIT.java
@@ -18,7 +18,11 @@ public class DefaultRxJavaBulkExecutorIT extends AbstractBulkExecutorIT {
 
   @BeforeClass
   public static void createBulkExecutors() {
-    failFastExecutor = DefaultRxJavaBulkExecutor.builder(session).build();
+    failFastExecutor =
+        DefaultRxJavaBulkExecutor.builder(session)
+            // serialize execution of statements to force results to be produced in deterministic order
+            .withMaxInFlightRequests(1)
+            .build();
     failSafeExecutor = DefaultRxJavaBulkExecutor.builder(session).failSafe().build();
   }
 }

--- a/tests/src/test/java/com/datastax/dsbulk/tests/ccm/CCMCluster.java
+++ b/tests/src/test/java/com/datastax/dsbulk/tests/ccm/CCMCluster.java
@@ -247,7 +247,8 @@ public interface CCMCluster extends Closeable {
   /**
    * Returns the Cassandra or DSE version of this CCM cluster.
    *
-   * <p>By default the version is inferred from {@link VersionUtils#getDefaultVersion(boolean)}.
+   * <p>By default the version is inferred from {@link VersionUtils#getBestDSEVersion(String)} or
+   * {@link VersionUtils#getBestOSSVersion(String)}.
    *
    * @return The version of this CCM cluster.
    */

--- a/tests/src/test/java/com/datastax/dsbulk/tests/ccm/CCMRule.java
+++ b/tests/src/test/java/com/datastax/dsbulk/tests/ccm/CCMRule.java
@@ -22,6 +22,7 @@ import com.google.common.io.Closer;
 import java.io.Closeable;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import javax.inject.Inject;
@@ -35,27 +36,13 @@ import org.slf4j.MDC;
 /**
  * A manager for {@link CCMCluster CCM} clusters that helps testing with JUnit 4 and Cassandra.
  *
- * <p>
- *
- * <p>
- *
- * <p>
- *
  * <p>This manager is a JUnit {@link org.junit.rules.TestRule rule} that must be declared in each
  * test class requiring CCM, like in the example below:
- *
- * <p>
- *
- * <p>
- *
- * <p>
  *
  * <pre>
  * &#64;Rule &#64;ClassRule
  * public static CCMRule ccmRule = new CCMRule();
  * </pre>
- *
- * <p>
  *
  * <p>Note that the field MUST be public, static, and annotated with {@link
  * org.junit.ClassRule @ClassRule}. Each test class must also be annotated with {@link
@@ -137,26 +124,30 @@ public class CCMRule implements TestRule {
   private void createAndInjectCloseables() throws IllegalAccessException {
     Set<Field> fields = ReflectionUtils.locateFieldsAnnotatedWith(testClass, Inject.class);
     for (Field field : fields) {
+      field.setAccessible(true);
+      assert Modifier.isStatic(field.getModifiers())
+          : String.format("Field %s is not static", field);
+      Class<?> type = field.getType();
+      assert Closeable.class.isAssignableFrom(type)
+          : String.format("Field %s is not Closeable", field);
+      Closeable value;
+      if (CCMCluster.class.isAssignableFrom(type)) {
+        value = ccm;
+      } else if (Session.class.isAssignableFrom(type)) {
+        Session session = getSession(field, testClass);
+        closer.register(session.getCluster());
+        value = session;
+      } else if (Cluster.class.isAssignableFrom(type)) {
+        value = getCluster(field, testClass);
+        closer.register(value);
+      } else {
+        throw new IllegalStateException("Cannot inject field " + field);
+      }
+      LOGGER.debug(String.format("Injecting %s into field %s", value, field));
       try {
-        Closeable value = null;
-        Class<?> type = field.getType();
-        if (CCMCluster.class.isAssignableFrom(type)) {
-          value = ccm;
-        } else if (Session.class.isAssignableFrom(type)) {
-          Session session = getSession(field, testClass);
-          closer.register(session.getCluster());
-          value = session;
-        } else if (Cluster.class.isAssignableFrom(type)) {
-          value = getCluster(field, testClass);
-          closer.register(value);
-        }
-        if (value != null) {
-          field.setAccessible(true);
-          field.set(null, value);
-        }
+        field.set(null, value);
       } catch (IllegalAccessException e) {
-        LOGGER.error(
-            String.format("Error while injecting field %s in instance %s", field, null), e);
+        LOGGER.error("Error while injecting field %s" + field, e);
         throw e;
       }
     }


### PR DESCRIPTION
Alternate approach to DAT-101: restrict the maximum number of inflight requests to 1 to enforce deterministic execution order.