### PR TITLE
DAT-112: Sort 'Bulk Loader effective settings' output

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -47,3 +47,4 @@
 - [bug] DAT-73: Make mappings work with quoted CQL identifiers.
 - [improvement] DAT-87: Validate configuration more deeply.
 - [improvement] DAT-110: Improve performance of read result mappers.
+- [improvement] DAT-112: Sort 'Bulk Loader effective settings' output.

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/settings/SettingsManager.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/settings/SettingsManager.java
@@ -10,7 +10,10 @@ import com.datastax.dsbulk.commons.config.LoaderConfig;
 import com.datastax.dsbulk.engine.WorkflowType;
 import com.typesafe.config.ConfigRenderOptions;
 import com.typesafe.config.ConfigValue;
+import java.util.Comparator;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +65,12 @@ public class SettingsManager {
 
   public void logEffectiveSettings() {
     LOGGER.info("Bulk Loader effective settings:");
-    for (Map.Entry<String, ConfigValue> entry : config.entrySet()) {
+
+    Set<Map.Entry<String, ConfigValue>> entries =
+        new TreeSet<>(Comparator.comparing(Map.Entry::getKey));
+    entries.addAll(config.entrySet());
+
+    for (Map.Entry<String, ConfigValue> entry : entries) {
       LOGGER.info(
           String.format(
               "%s = %s", entry.getKey(), entry.getValue().render(ConfigRenderOptions.concise())));


### PR DESCRIPTION
For [DAT-112](https://datastax.jira.com/browse/DAT-112).  This is a trivial change that orders the output of settings in ascending alphabetical order.