### PR TITLE
DAT-49: Allow mappings to be inferred even when some are provided.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -51,3 +51,4 @@
 - [improvement] DAT-112: Sort 'Bulk Loader effective settings' output.
 - [improvement] DAT-99: schema.keyspace should scope underlying session to the provided keyspace.
 - [improvement] DAT-115: Make continuous paging optional.
+- [improvement] DAT-49: Allow mappings to be inferred even when some are provided.

--- a/commons/src/main/java/com/datastax/dsbulk/commons/internal/config/ConfigUtils.java
+++ b/commons/src/main/java/com/datastax/dsbulk/commons/internal/config/ConfigUtils.java
@@ -26,9 +26,16 @@ public class ConfigUtils {
               + errorMsg
               + ". See settings.md or help for more info.",
           path);
-    }
-    // This will catch any parse or missing exception edge cases.
-    else {
+    } else if (e instanceof ConfigException.Parse) {
+      return new BulkConfigurationException(
+          "Configuration entry of "
+              + path
+              + ". "
+              + e.getMessage()
+              + ". See settings.md or help for more info.",
+          path);
+    } else {
+      // Catch-all for other types of exceptions.
       return new BulkConfigurationException(e.getMessage(), path);
     }
   }

--- a/engine/src/main/resources/reference.conf
+++ b/engine/src/main/resources/reference.conf
@@ -582,6 +582,14 @@ dsbulk {
     # - Indexed data sources: `0 = col1, 1 = col2, 2 = col3`, where `0`, `1`, `2`, etc. are the zero-based indices of fields in the source data; and `col1`, `col2`, `col3` are bound variable names in the insert statement.
     # - Mapped data sources: `fieldA = col1, fieldB = col2, fieldC = col3`, where `fieldA`, `fieldB`, `fieldC`, etc. are field names in the source data; and `col1`, `col2`, `col3` are bound variable names in the insert statement.
     #
+    # In addition, for mapped data sources, it is also possible to specify that the mapping be partly auto-generated and partly explicitly specified. For example, if a source row has fields c1, c2, c3, and c5, and the table has columns c1, c2, c3, c4, one can map all like-named columns and specify that c5 in the source maps to c4 in the table as follows: `* = *, c5 = c4`
+    #
+    # One can specify that all like-named fields be mapped, except for c2: `* = -c2`
+    #
+    # To skip c2 and c3: `* = [-c2, -c3]`
+    #
+    # To only map c1 and c2: `* = [c1, c2]`
+    #
     # The exact type of mapping to use depends on the connector being used. Some connectors can only produce indexed records; others can only produce mapped ones, while others are capable of producing both indexed and mapped records at the same time. Refer to the connector's documentation to know which kinds of mapping it supports.
     mapping: ""
 

--- a/manual/settings.md
+++ b/manual/settings.md
@@ -154,6 +154,14 @@ Mappings should be specified as a HOCON map (https://github.com/typesafehub/conf
 - Indexed data sources: `0 = col1, 1 = col2, 2 = col3`, where `0`, `1`, `2`, etc. are the zero-based indices of fields in the source data; and `col1`, `col2`, `col3` are bound variable names in the insert statement.
 - Mapped data sources: `fieldA = col1, fieldB = col2, fieldC = col3`, where `fieldA`, `fieldB`, `fieldC`, etc. are field names in the source data; and `col1`, `col2`, `col3` are bound variable names in the insert statement.
 
+In addition, for mapped data sources, it is also possible to specify that the mapping be partly auto-generated and partly explicitly specified. For example, if a source row has fields c1, c2, c3, and c5, and the table has columns c1, c2, c3, c4, one can map all like-named columns and specify that c5 in the source maps to c4 in the table as follows: `* = *, c5 = c4`
+
+One can specify that all like-named fields be mapped, except for c2: `* = -c2`
+
+To skip c2 and c3: `* = [-c2, -c3]`
+
+To only map c1 and c2: `* = [c1, c2]`
+
 The exact type of mapping to use depends on the connector being used. Some connectors can only produce indexed records; others can only produce mapped ones, while others are capable of producing both indexed and mapped records at the same time. Refer to the connector's documentation to know which kinds of mapping it supports.
 
 Default: **&lt;unspecified&gt;**.
@@ -453,6 +461,14 @@ Mappings should be specified as a HOCON map (https://github.com/typesafehub/conf
 
 - Indexed data sources: `0 = col1, 1 = col2, 2 = col3`, where `0`, `1`, `2`, etc. are the zero-based indices of fields in the source data; and `col1`, `col2`, `col3` are bound variable names in the insert statement.
 - Mapped data sources: `fieldA = col1, fieldB = col2, fieldC = col3`, where `fieldA`, `fieldB`, `fieldC`, etc. are field names in the source data; and `col1`, `col2`, `col3` are bound variable names in the insert statement.
+
+In addition, for mapped data sources, it is also possible to specify that the mapping be partly auto-generated and partly explicitly specified. For example, if a source row has fields c1, c2, c3, and c5, and the table has columns c1, c2, c3, c4, one can map all like-named columns and specify that c5 in the source maps to c4 in the table as follows: `* = *, c5 = c4`
+
+One can specify that all like-named fields be mapped, except for c2: `* = -c2`
+
+To skip c2 and c3: `* = [-c2, -c3]`
+
+To only map c1 and c2: `* = [c1, c2]`
 
 The exact type of mapping to use depends on the connector being used. Some connectors can only produce indexed records; others can only produce mapped ones, while others are capable of producing both indexed and mapped records at the same time. Refer to the connector's documentation to know which kinds of mapping it supports.
 


### PR DESCRIPTION
* Introduce `* = <spec>` syntax to specify which mappings to infer.