### PR TITLE
DAT-117: Support blob and duration types

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -55,3 +55,4 @@
 - [improvement] DAT-91: Add SSL/Auth Tests. Fix issue with ssl config and file paths.
 - [improvement] DAT-107: Improve formatting of help section on the command line.
 - [bug] DAT-100: Fully support CQL complex types.
+- [improvement] DAT-117: Support blob and duration types.

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/ExtendedCodecRegistry.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/ExtendedCodecRegistry.java
@@ -19,9 +19,11 @@ import com.datastax.driver.extras.codecs.jdk8.LocalDateCodec;
 import com.datastax.driver.extras.codecs.jdk8.LocalTimeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToBigDecimalCodec;
 import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToBigIntegerCodec;
+import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToBlobCodec;
 import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToBooleanCodec;
 import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToByteCodec;
 import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToDoubleCodec;
+import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToDurationCodec;
 import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToFloatCodec;
 import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToInetAddressCodec;
 import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToInstantCodec;
@@ -39,9 +41,11 @@ import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToUDTCodec;
 import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToUUIDCodec;
 import com.datastax.dsbulk.engine.internal.codecs.string.StringToBigDecimalCodec;
 import com.datastax.dsbulk.engine.internal.codecs.string.StringToBigIntegerCodec;
+import com.datastax.dsbulk.engine.internal.codecs.string.StringToBlobCodec;
 import com.datastax.dsbulk.engine.internal.codecs.string.StringToBooleanCodec;
 import com.datastax.dsbulk.engine.internal.codecs.string.StringToByteCodec;
 import com.datastax.dsbulk.engine.internal.codecs.string.StringToDoubleCodec;
+import com.datastax.dsbulk.engine.internal.codecs.string.StringToDurationCodec;
 import com.datastax.dsbulk.engine.internal.codecs.string.StringToFloatCodec;
 import com.datastax.dsbulk.engine.internal.codecs.string.StringToInetAddressCodec;
 import com.datastax.dsbulk.engine.internal.codecs.string.StringToInstantCodec;
@@ -194,6 +198,10 @@ public class ExtendedCodecRegistry {
         return new StringToUUIDCodec(TypeCodec.uuid());
       case TIMEUUID:
         return new StringToUUIDCodec(TypeCodec.timeUUID());
+      case BLOB:
+        return StringToBlobCodec.INSTANCE;
+      case DURATION:
+        return StringToDurationCodec.INSTANCE;
       case LIST:
         {
           @SuppressWarnings("unchecked")
@@ -227,15 +235,13 @@ public class ExtendedCodecRegistry {
               (JsonNodeToUDTCodec) createJsonNodeConvertingCodec(cqlType);
           return new StringToUDTCodec(jsonCodec, objectMapper);
         }
-      case BLOB:
-      case DURATION:
       case COUNTER:
       case CUSTOM:
       default:
         String msg =
             String.format(
-                "Codec not found for requested operation: [%s <-> %s]", cqlType, JsonNode.class);
-        throw new CodecNotFoundException(msg, cqlType, JSON_NODE_TYPE_TOKEN);
+                "Codec not found for requested operation: [%s <-> %s]", cqlType, String.class);
+        throw new CodecNotFoundException(msg, cqlType, STRING_TYPE_TOKEN);
     }
   }
 
@@ -276,6 +282,10 @@ public class ExtendedCodecRegistry {
         return new JsonNodeToUUIDCodec(TypeCodec.uuid());
       case TIMEUUID:
         return new JsonNodeToUUIDCodec(TypeCodec.timeUUID());
+      case BLOB:
+        return JsonNodeToBlobCodec.INSTANCE;
+      case DURATION:
+        return JsonNodeToDurationCodec.INSTANCE;
       case LIST:
         {
           DataType elementType = cqlType.getTypeArguments().get(0);
@@ -328,8 +338,6 @@ public class ExtendedCodecRegistry {
           }
           return new JsonNodeToUDTCodec(udtCodec, fieldCodecs.build(), objectMapper);
         }
-      case BLOB:
-      case DURATION:
       case COUNTER:
       case CUSTOM:
       default:

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBlobCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBlobCodec.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2017 DataStax Inc.
+ *
+ * This software can be used solely with DataStax Enterprise. Please consult the license at
+ * http://www.datastax.com/terms/datastax-dse-driver-license-terms
+ */
+package com.datastax.dsbulk.engine.internal.codecs.json;
+
+import com.datastax.driver.core.exceptions.InvalidTypeException;
+import com.datastax.driver.core.utils.Bytes;
+import com.datastax.dsbulk.engine.internal.codecs.ConvertingCodec;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import java.nio.ByteBuffer;
+import java.util.Base64;
+
+public class JsonNodeToBlobCodec extends ConvertingCodec<JsonNode, ByteBuffer> {
+
+  public static final JsonNodeToBlobCodec INSTANCE = new JsonNodeToBlobCodec();
+
+  private JsonNodeToBlobCodec() {
+    super(blob(), JsonNode.class);
+  }
+
+  @Override
+  public ByteBuffer convertFrom(JsonNode node) {
+    if (node == null || node.isNull()) {
+      return null;
+    }
+    String s = node.asText();
+    if (s == null || s.isEmpty()) {
+      return null;
+    }
+    try {
+      return Bytes.fromHexString(s);
+    } catch (IllegalArgumentException e) {
+      try {
+        return ByteBuffer.wrap(Base64.getDecoder().decode(s));
+      } catch (IllegalArgumentException e1) {
+        e1.addSuppressed(e);
+        throw new InvalidTypeException("Invalid binary string: " + s, e1);
+      }
+    }
+  }
+
+  @Override
+  public JsonNode convertTo(ByteBuffer value) {
+    if (value == null) {
+      return JsonNodeFactory.instance.nullNode();
+    }
+    return JsonNodeFactory.instance.binaryNode(Bytes.getArray(value));
+  }
+}

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToDurationCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToDurationCodec.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2017 DataStax Inc.
+ *
+ * This software can be used solely with DataStax Enterprise. Please consult the license at
+ * http://www.datastax.com/terms/datastax-dse-driver-license-terms
+ */
+package com.datastax.dsbulk.engine.internal.codecs.json;
+
+import com.datastax.driver.core.Duration;
+import com.datastax.dsbulk.engine.internal.codecs.ConvertingCodec;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+public class JsonNodeToDurationCodec extends ConvertingCodec<JsonNode, Duration> {
+
+  public static final JsonNodeToDurationCodec INSTANCE = new JsonNodeToDurationCodec();
+
+  private JsonNodeToDurationCodec() {
+    super(duration(), JsonNode.class);
+  }
+
+  @Override
+  public Duration convertFrom(JsonNode node) {
+    if (node == null || node.isNull()) {
+      return null;
+    }
+    String s = node.asText();
+    if (s == null || s.isEmpty()) {
+      return null;
+    }
+    return Duration.from(s);
+  }
+
+  @Override
+  public JsonNode convertTo(Duration value) {
+    if (value == null) {
+      return null;
+    }
+    return JsonNodeFactory.instance.textNode(value.toString());
+  }
+}

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBlobCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBlobCodec.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2017 DataStax Inc.
+ *
+ * This software can be used solely with DataStax Enterprise. Please consult the license at
+ * http://www.datastax.com/terms/datastax-dse-driver-license-terms
+ */
+package com.datastax.dsbulk.engine.internal.codecs.string;
+
+import com.datastax.driver.core.exceptions.InvalidTypeException;
+import com.datastax.driver.core.utils.Bytes;
+import com.datastax.dsbulk.engine.internal.codecs.ConvertingCodec;
+import java.nio.ByteBuffer;
+import java.util.Base64;
+
+public class StringToBlobCodec extends ConvertingCodec<String, ByteBuffer> {
+
+  public static final StringToBlobCodec INSTANCE = new StringToBlobCodec();
+
+  private StringToBlobCodec() {
+    super(blob(), String.class);
+  }
+
+  @Override
+  public ByteBuffer convertFrom(String s) {
+    if (s == null || s.isEmpty()) {
+      return null;
+    }
+    try {
+      return Bytes.fromHexString(s);
+    } catch (IllegalArgumentException e) {
+      try {
+        return ByteBuffer.wrap(Base64.getDecoder().decode(s));
+      } catch (IllegalArgumentException e1) {
+        e1.addSuppressed(e);
+        throw new InvalidTypeException("Invalid binary string: " + s, e1);
+      }
+    }
+  }
+
+  @Override
+  public String convertTo(ByteBuffer value) {
+    if (value == null) {
+      return null;
+    }
+    return Base64.getEncoder().encodeToString(Bytes.getArray(value));
+  }
+}

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToDurationCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToDurationCodec.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2017 DataStax Inc.
+ *
+ * This software can be used solely with DataStax Enterprise. Please consult the license at
+ * http://www.datastax.com/terms/datastax-dse-driver-license-terms
+ */
+package com.datastax.dsbulk.engine.internal.codecs.string;
+
+import com.datastax.driver.core.Duration;
+import com.datastax.dsbulk.engine.internal.codecs.ConvertingCodec;
+
+public class StringToDurationCodec extends ConvertingCodec<String, Duration> {
+
+  public static final StringToDurationCodec INSTANCE = new StringToDurationCodec();
+
+  private StringToDurationCodec() {
+    super(duration(), String.class);
+  }
+
+  @Override
+  public Duration convertFrom(String s) {
+    if (s == null || s.isEmpty()) {
+      return null;
+    }
+    return Duration.from(s);
+  }
+
+  @Override
+  public String convertTo(Duration value) {
+    if (value == null) {
+      return null;
+    }
+    return value.toString();
+  }
+}

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBlobCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBlobCodecTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2017 DataStax Inc.
+ *
+ * This software can be used solely with DataStax Enterprise. Please consult the license at
+ * http://www.datastax.com/terms/datastax-dse-driver-license-terms
+ */
+package com.datastax.dsbulk.engine.internal.codecs.json;
+
+import static com.datastax.dsbulk.engine.internal.Assertions.assertThat;
+
+import com.datastax.driver.core.utils.Bytes;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import org.junit.Test;
+
+public class JsonNodeToBlobCodecTest {
+
+  private static final byte[] DATA = {1, 2, 3, 4, 5, 6};
+  private static final byte[] EMPTY = {};
+
+  private static final ByteBuffer DATA_BB = ByteBuffer.wrap(DATA);
+  private static final ByteBuffer EMPTY_BB = ByteBuffer.wrap(EMPTY);
+
+  private static final String DATA_64 = Base64.getEncoder().encodeToString(DATA);
+  private static final String DATA_HEX = Bytes.toHexString(DATA);
+
+  private static final String EMPTY_HEX = "0x";
+
+  JsonNodeToBlobCodec codec = JsonNodeToBlobCodec.INSTANCE;
+
+  @Test
+  public void should_convert_from_valid_input() throws Exception {
+    assertThat(codec)
+        .convertsFrom(JsonNodeFactory.instance.binaryNode(DATA))
+        .to(DATA_BB)
+        .convertsFrom(JsonNodeFactory.instance.binaryNode(EMPTY))
+        .to(null)
+        .convertsFrom(JsonNodeFactory.instance.textNode(DATA_64))
+        .to(DATA_BB)
+        .convertsFrom(JsonNodeFactory.instance.textNode(DATA_HEX))
+        .to(DATA_BB)
+        .convertsFrom(JsonNodeFactory.instance.textNode(EMPTY_HEX))
+        .to(EMPTY_BB)
+        .convertsFrom(JsonNodeFactory.instance.textNode(""))
+        .to(null)
+        .convertsFrom(JsonNodeFactory.instance.nullNode())
+        .to(null)
+        .convertsFrom(null)
+        .to(null);
+  }
+
+  @Test
+  public void should_convert_to_valid_input() throws Exception {
+    assertThat(codec)
+        .convertsTo(DATA_BB)
+        .from(JsonNodeFactory.instance.binaryNode(DATA))
+        .convertsTo(EMPTY_BB)
+        .from(JsonNodeFactory.instance.binaryNode(EMPTY))
+        .convertsTo(null)
+        .from(JsonNodeFactory.instance.nullNode());
+  }
+
+  @Test
+  public void should_not_convert_from_invalid_input() throws Exception {
+    assertThat(codec).cannotConvertFrom(JsonNodeFactory.instance.textNode("not a valid binary"));
+  }
+}

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToDurationCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToDurationCodecTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2017 DataStax Inc.
+ *
+ * This software can be used solely with DataStax Enterprise. Please consult the license at
+ * http://www.datastax.com/terms/datastax-dse-driver-license-terms
+ */
+package com.datastax.dsbulk.engine.internal.codecs.json;
+
+import static com.datastax.dsbulk.engine.internal.Assertions.assertThat;
+
+import com.datastax.driver.core.Duration;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import org.junit.Test;
+
+public class JsonNodeToDurationCodecTest {
+
+  static final long NANOS_PER_MINUTE = 60 * 1000L * 1000L * 1000L;
+
+  Duration duration = Duration.newInstance(15, 0, 130 * NANOS_PER_MINUTE);
+
+  JsonNodeToDurationCodec codec = JsonNodeToDurationCodec.INSTANCE;
+
+  @Test
+  public void should_convert_from_valid_input() throws Exception {
+    assertThat(codec)
+        .convertsFrom(JsonNodeFactory.instance.textNode("1y3mo2h10m")) // standard pattern
+        .to(duration)
+        .convertsFrom(JsonNodeFactory.instance.textNode("P1Y3MT2H10M")) // ISO 8601 pattern
+        .to(duration)
+        .convertsFrom(
+            JsonNodeFactory.instance.textNode(
+                "P0001-03-00T02:10:00")) // alternative ISO 8601 pattern
+        .to(duration)
+        .convertsFrom(JsonNodeFactory.instance.textNode(""))
+        .to(null)
+        .convertsFrom(JsonNodeFactory.instance.nullNode())
+        .to(null)
+        .convertsFrom(null)
+        .to(null);
+  }
+
+  @Test
+  public void should_convert_to_valid_input() throws Exception {
+    assertThat(codec)
+        .convertsTo(duration)
+        .from(JsonNodeFactory.instance.textNode("1y3mo2h10m"))
+        .convertsTo(null)
+        .from(null);
+  }
+
+  @Test
+  public void should_not_convert_from_invalid_input() throws Exception {
+    assertThat(codec)
+        .cannotConvertFrom(
+            JsonNodeFactory.instance.textNode("1Y3M4D")) // The minutes should be after days
+        .cannotConvertFrom(JsonNodeFactory.instance.textNode("not a valid duration"));
+  }
+}

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBlobCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBlobCodecTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2017 DataStax Inc.
+ *
+ * This software can be used solely with DataStax Enterprise. Please consult the license at
+ * http://www.datastax.com/terms/datastax-dse-driver-license-terms
+ */
+package com.datastax.dsbulk.engine.internal.codecs.string;
+
+import static com.datastax.dsbulk.engine.internal.Assertions.assertThat;
+
+import com.datastax.driver.core.utils.Bytes;
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import org.junit.Test;
+
+public class StringToBlobCodecTest {
+
+  private static final byte[] DATA = {1, 2, 3, 4, 5, 6};
+  private static final byte[] EMPTY = {};
+
+  private static final ByteBuffer DATA_BB = ByteBuffer.wrap(DATA);
+  private static final ByteBuffer EMPTY_BB = ByteBuffer.wrap(EMPTY);
+
+  private static final String DATA_64 = Base64.getEncoder().encodeToString(DATA);
+  private static final String DATA_HEX = Bytes.toHexString(DATA);
+
+  private static final String EMPTY_HEX = "0x";
+
+  StringToBlobCodec codec = StringToBlobCodec.INSTANCE;
+
+  @Test
+  public void should_convert_from_valid_input() throws Exception {
+    assertThat(codec)
+        .convertsFrom(DATA_64)
+        .to(DATA_BB)
+        .convertsFrom(DATA_HEX)
+        .to(DATA_BB)
+        .convertsFrom(EMPTY_HEX)
+        .to(EMPTY_BB)
+        .convertsFrom("")
+        .to(null)
+        .convertsFrom(null)
+        .to(null);
+  }
+
+  @Test
+  public void should_convert_to_valid_input() throws Exception {
+    assertThat(codec)
+        .convertsTo(DATA_BB)
+        .from(DATA_64)
+        .convertsTo(EMPTY_BB)
+        .from("")
+        .convertsTo(null)
+        .from(null);
+  }
+
+  @Test
+  public void should_not_convert_from_invalid_input() throws Exception {
+    assertThat(codec).cannotConvertFrom("not a valid binary");
+  }
+}

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToDurationCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToDurationCodecTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2017 DataStax Inc.
+ *
+ * This software can be used solely with DataStax Enterprise. Please consult the license at
+ * http://www.datastax.com/terms/datastax-dse-driver-license-terms
+ */
+package com.datastax.dsbulk.engine.internal.codecs.string;
+
+import static com.datastax.dsbulk.engine.internal.Assertions.assertThat;
+
+import com.datastax.driver.core.Duration;
+import org.junit.Test;
+
+public class StringToDurationCodecTest {
+
+  static final long NANOS_PER_MINUTE = 60 * 1000L * 1000L * 1000L;
+
+  Duration duration = Duration.newInstance(15, 0, 130 * NANOS_PER_MINUTE);
+
+  StringToDurationCodec codec = StringToDurationCodec.INSTANCE;
+
+  @Test
+  public void should_convert_from_valid_input() throws Exception {
+    assertThat(codec)
+        .convertsFrom("1y3mo2h10m") // standard pattern
+        .to(duration)
+        .convertsFrom("P1Y3MT2H10M") // ISO 8601 pattern
+        .to(duration)
+        .convertsFrom("P0001-03-00T02:10:00") // alternative ISO 8601 pattern
+        .to(duration)
+        .convertsFrom("")
+        .to(null)
+        .convertsFrom(null)
+        .to(null);
+  }
+
+  @Test
+  public void should_convert_to_valid_input() throws Exception {
+    assertThat(codec).convertsTo(duration).from("1y3mo2h10m").convertsTo(null).from(null);
+  }
+
+  @Test
+  public void should_not_convert_from_invalid_input() throws Exception {
+    assertThat(codec)
+        .cannotConvertFrom("1Y3M4D") // The minutes should be after days
+        .cannotConvertFrom("not a valid duration");
+  }
+}


### PR DESCRIPTION
For blobs, I propose to accept both `0x` hexadecimal notation and Base 64.