### PR TITLE
Update simulacron to 0.5.4 and adjust query log filter criteria

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -142,7 +142,7 @@
     <dependency>
       <groupId>com.datastax.oss.simulacron</groupId>
       <artifactId>simulacron-native-server</artifactId>
-      <version>0.5.3</version>
+      <version>0.5.4</version>
     </dependency>
   </dependencies>
 

--- a/tests/src/it/java/com/datastax/dsbulk/executor/api/simulacron/AbstractBulkExecutorSimulacronIT.java
+++ b/tests/src/it/java/com/datastax/dsbulk/executor/api/simulacron/AbstractBulkExecutorSimulacronIT.java
@@ -1142,7 +1142,11 @@ public abstract class AbstractBulkExecutorSimulacronIT {
             .getLogs()
             .getQueryLogs()
             .stream()
-            .filter((l) -> !l.getQuery().equals(failedStr))
+            .filter(
+                (l) ->
+                    (l.getType().equals("EXECUTE") || l.getType().equals("QUERY"))
+                        && !l.getQuery().contains("system")
+                        && !l.getQuery().equals(failedStr))
             .count();
 
     Assertions.assertThat(size).isEqualTo(expected);

--- a/tests/src/test/java/com/datastax/dsbulk/tests/utils/EndToEndUtils.java
+++ b/tests/src/test/java/com/datastax/dsbulk/tests/utils/EndToEndUtils.java
@@ -210,7 +210,9 @@ public class EndToEndUtils {
       SimulacronRule simulacron, int numOfQueries, String query, ConsistencyLevel level) {
     List<QueryLog> logs = simulacron.cluster().getLogs().getQueryLogs();
     List<QueryLog> ipLogs =
-        logs.stream().filter(l -> l.getQuery().startsWith(query)).collect(Collectors.toList());
+        logs.stream()
+            .filter(l -> !l.getType().equals("PREPARE") && l.getQuery().startsWith(query))
+            .collect(Collectors.toList());
     Assertions.assertThat(ipLogs.size()).isEqualTo(numOfQueries);
     for (QueryLog log : ipLogs) {
       Assertions.assertThat(log.getConsistency()).isEqualTo(level);


### PR DESCRIPTION
`STARTUP` and `system` table messages sent by driver show up in query logs, need to filter these out.  With Simulacron 0.5.4, we emit all messages received by the server now, so we also need to filter out `PREPARE` and other messages where applicable.