### PR TITLE
DAT-81: Surface setup errors better.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -73,3 +73,4 @@
 - [bug] DAT-128: Last recorded locations should be 100% accurate.
 - [bug] DAT-144: When columns are larger than 4096 characters we error out.
 - [improvement] DAT-92: schema.mapping should support specifying an array of target columns.
+- [improvement] DAT-81: Surface setup errors better.

--- a/engine/src/main/java/com/datastax/dsbulk/engine/Main.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/Main.java
@@ -8,6 +8,7 @@ package com.datastax.dsbulk.engine;
 
 import static com.datastax.dsbulk.engine.internal.OptionUtils.DEFAULT;
 
+import com.datastax.driver.core.exceptions.DriverException;
 import com.datastax.dsbulk.commons.config.LoaderConfig;
 import com.datastax.dsbulk.commons.internal.config.DefaultLoaderConfig;
 import com.datastax.dsbulk.commons.url.LoaderURLStreamHandlerFactory;
@@ -216,6 +217,9 @@ public class Main {
         if (t instanceof InterruptedException || root instanceof InterruptedException) {
           LOGGER.error(workflow + " aborted.", t);
           // do not set the thread's interrupted status, we are going to exit anyway
+        } else if (t instanceof DriverException) {
+          LOGGER.error(workflow + " failed.");
+          LOGGER.error(t.getMessage());
         } else {
           LOGGER.error(workflow + " failed.", t);
         }


### PR DESCRIPTION
* Don't emit a stack trace for driver errors; the exception message is good enough.