### PR TITLE
DAT-108: Upgrade DSE driver to 1.6.1

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -6,6 +6,7 @@
 - [new feature] DAT-172: Support numeric-to-temporal conversions.
 - [new feature] DAT-175: Support temporal-to-numeric conversions.
 - [enhancement] DAT-167: Add support for user-supplied execution ids.
+- [improvement] DAT-108: Upgrade DSE driver to 1.6.0.
 
 
 ### 1.0.0-beta2

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -24,13 +24,6 @@
     Binary distribution of the DataStax Bulk Loader.
   </description>
 
-  <properties>
-    <joda.version>2.9.9</joda.version>
-    <jsr353-api.version>1.0</jsr353-api.version>
-    <esri.version>1.2.1</esri.version>
-    <osgi-core.version>4.3.0</osgi-core.version>
-  </properties>
-
   <dependencies>
 
     <dependency>
@@ -73,20 +66,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-    </dependency>
-
-    <!-- source artifacts -->
-
-    <dependency>
-      <groupId>com.datastax.dse</groupId>
-      <artifactId>dse-java-driver-core</artifactId>
-      <classifier>sources</classifier>
-    </dependency>
-
-    <dependency>
-      <groupId>com.datastax.dse</groupId>
-      <artifactId>dse-java-driver-extras</artifactId>
-      <classifier>sources</classifier>
     </dependency>
 
   </dependencies>
@@ -147,26 +126,16 @@
             <artifactId>maven-javadoc-plugin</artifactId>
             <executions>
               <execution>
-                <id>attach-sources</id>
-                <configuration>
-                  <skip>true</skip>
-                </configuration>
-              </execution>
-              <execution>
-                <id>dependencies-javadoc</id>
-                <phase>package</phase>
+                <id>attach-javadocs</id>
                 <goals>
                   <goal>jar</goal>
                 </goals>
                 <configuration>
                   <includeDependencySources>true</includeDependencySources>
-                  <includeTransitiveDependencySources>true</includeTransitiveDependencySources>
                   <dependencySourceIncludes>
-                    <dependencySourceInclude>com.datastax.*</dependencySourceInclude>
+                    <dependencySourceInclude>com.datastax.dse:dsbulk-*</dependencySourceInclude>
                   </dependencySourceIncludes>
-                  <excludePackageNames>*.internal:internal.*</excludePackageNames>
-                  <!-- required unfortunately because javadocs from the java driver do not comply -->
-                  <additionalparam>-Xdoclint:none</additionalparam>
+                  <excludePackageNames>*.internal:*.internal.*</excludePackageNames>
                   <additionalDependencies>
                     <!--
                     dependencies from this project;
@@ -177,31 +146,6 @@
                       <groupId>io.reactivex.rxjava2</groupId>
                       <artifactId>rxjava</artifactId>
                       <version>${rx-java.version}</version>
-                    </additionalDependency>
-                    <!--
-                    dependencies from the java driver;
-                    not used in this project but required
-                    for javadoc generation
-                    -->
-                    <additionalDependency>
-                      <groupId>org.osgi</groupId>
-                      <artifactId>org.osgi.core</artifactId>
-                      <version>${osgi-core.version}</version>
-                    </additionalDependency>
-                    <additionalDependency>
-                      <groupId>joda-time</groupId>
-                      <artifactId>joda-time</artifactId>
-                      <version>${joda.version}</version>
-                    </additionalDependency>
-                    <additionalDependency>
-                      <groupId>javax.json</groupId>
-                      <artifactId>javax.json-api</artifactId>
-                      <version>${jsr353-api.version}</version>
-                    </additionalDependency>
-                    <additionalDependency>
-                      <groupId>com.esri.geometry</groupId>
-                      <artifactId>esri-geometry-api</artifactId>
-                      <version>${esri.version}</version>
                     </additionalDependency>
                   </additionalDependencies>
                 </configuration>

--- a/dist/src/assembly/binary-distro.xml
+++ b/dist/src/assembly/binary-distro.xml
@@ -62,21 +62,7 @@
       <excludes>
         <!-- Guava dependency that must be kept during build, but can be discarded now -->
         <exclude>org.codehaus.mojo:animal-sniffer-annotations*</exclude>
-        <!-- do not include source jars here -->
-        <exclude>com.datastax.*:*:jar:sources:*</exclude>
       </excludes>
-    </dependencySet>
-
-    <!-- sources for DataStax-owned dependencies (driver) -->
-    <dependencySet>
-      <outputDirectory>src</outputDirectory>
-      <useProjectArtifact>false</useProjectArtifact>
-      <scope>runtime</scope>
-      <includes>
-        <include>com.datastax.*:*:jar:sources:*</include>
-      </includes>
-      <unpack>false</unpack>
-      <outputFileNameMapping>${artifact.artifactId}-${artifact.version}-src.zip</outputFileNameMapping>
     </dependencySet>
 
   </dependencySets>

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/WorkflowUtils.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/WorkflowUtils.java
@@ -50,7 +50,8 @@ public class WorkflowUtils {
     return workflowType + "_" + DEFAULT_TIMESTAMP_PATTERN.format(now());
   }
 
-  public static String newCustomExecutionId(@NotNull String template, @NotNull WorkflowType workflowType) {
+  public static String newCustomExecutionId(
+      @NotNull String template, @NotNull WorkflowType workflowType) {
     try {
       // Accepted parameters:
       // 1 : the workflow type

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/settings/CodecSettingsTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/settings/CodecSettingsTest.java
@@ -27,7 +27,7 @@ import static com.datastax.driver.core.DataType.varint;
 import static com.datastax.driver.core.DriverCoreEngineTestHooks.newField;
 import static com.datastax.driver.core.DriverCoreEngineTestHooks.newTupleType;
 import static com.datastax.driver.core.DriverCoreEngineTestHooks.newUserType;
-import static com.datastax.dsbulk.commons.internal.assertions.CommonsAssertions.assertThat;
+import static com.datastax.dsbulk.engine.internal.EngineAssertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/manual/application.template.conf
+++ b/manual/application.template.conf
@@ -961,7 +961,7 @@
 # Parsing](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns))
 # in UTC, with microsecond precision if available, and millisecond precision otherwise.
 # 
-# When this identifier is user-supplied, it is important to guarantee its unicity; failing to do so
+# When this identifier is user-supplied, it is important to guarantee its uniqueness; failing to do so
 # may result in execution failures.
 # 
 # It is also possible to provide templates here. Any format compliant with the formatting rules of

--- a/manual/settings.md
+++ b/manual/settings.md
@@ -1165,7 +1165,7 @@ When unspecified or empty, the engine will automatically generate identifiers of
 - `<workflow>` stands for the workflow type (`LOAD`, `UNLOAD`, etc.);
 - `<timestamp>` is the current timestamp formatted as `uuuuMMdd-HHmmss-SSSSSS` (see [Patterns for Formatting and Parsing](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns)) in UTC, with microsecond precision if available, and millisecond precision otherwise.
 
-When this identifier is user-supplied, it is important to guarantee its unicity; failing to do so may result in execution failures.
+When this identifier is user-supplied, it is important to guarantee its uniqueness; failing to do so may result in execution failures.
 
 It is also possible to provide templates here. Any format compliant with the formatting rules of [`String.format()`](https://docs.oracle.com/javase/8/docs/api/java/util/Formatter.html#syntax) is accepted, and can contain the following parameters:
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>
-    <driver.version>1.4.2</driver.version>
+    <driver.version>1.6.2</driver.version>
     <reactive-streams.version>1.0.1</reactive-streams.version>
     <rx-java.version>2.1.7</rx-java.version>
     <reactor.version>Bismuth-SR4</reactor.version>
@@ -739,6 +739,20 @@ http://www.datastax.com/terms/datastax-dse-driver-license-terms
     </profile>
 
   </profiles>
+
+  <repositories>
+    <repository>
+      <id>datastax-releases-local</id>
+      <name>DataStax Local Releases</name>
+      <url>https://datastax.jfrog.io/datastax/datastax-releases-local/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 
   <distributionManagement>
     <repository>


### PR DESCRIPTION
Trickier than I imagined:

1. There was one binary compatibility break in an internal API
2. Sources for the java driver are not available anymore, which broke our build
3. The javadoc generation was probably broken for a while too, now it's fixed
4. Seized the opportunity to fix a duplicate class issue: `DriverCoreTestHooks` used to appear twice, which is dangerous because one never knows which one will be loaded at runtime.