### PR TITLE
Upgrade to simulacron 0.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <mockito.version>1.10.19</mockito.version>
     <commons-exec.version>1.3</commons-exec.version>
     <commons-cli.version>1.4</commons-cli.version>
-    <simulacron.version>0.5.6</simulacron.version>
+    <simulacron.version>0.6.0</simulacron.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Includes update to jackson-databind 2.9.2 which has a fix for [CVE-2017-15095](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-15095).  Since jackson is only used by our test code this is not really a concern.