### PR TITLE
DAT-225: Change driver.pooling.local.connections default to 8

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -42,6 +42,7 @@
 - [improvement] DAT-214: driver.auth.principal should be optional when using Kerberos.
 - [improvement] DAT-207: Rename driver.auth.saslProtocol to driver.auth.saslService.
 - [improvement] DAT-215: When validating path-based settings, verify file existence.
+- [improvement] DAT-225: Change driver.pooling.local.connections default to 8.
 
 
 ### 1.0.0-beta2

--- a/engine/src/main/resources/reference.conf
+++ b/engine/src/main/resources/reference.conf
@@ -36,7 +36,7 @@ dsbulk {
       local {
 
         # The number of connections in the pool for nodes at "local" distance.
-        connections = 4
+        connections = 8
 
         # The maximum number of requests (1 to 32768) that can be executed concurrently on a connection.
         requests = 32768

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/settings/DriverSettingsTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/settings/DriverSettingsTest.java
@@ -104,8 +104,8 @@ class DriverSettingsTest {
     assertThat(queryOptions.getFetchSize()).isEqualTo(5000);
     assertThat(queryOptions.getDefaultIdempotence()).isTrue();
     PoolingOptions poolingOptions = configuration.getPoolingOptions();
-    assertThat(poolingOptions.getCoreConnectionsPerHost(LOCAL)).isEqualTo(4);
-    assertThat(poolingOptions.getMaxConnectionsPerHost(LOCAL)).isEqualTo(4);
+    assertThat(poolingOptions.getCoreConnectionsPerHost(LOCAL)).isEqualTo(8);
+    assertThat(poolingOptions.getMaxConnectionsPerHost(LOCAL)).isEqualTo(8);
     assertThat(poolingOptions.getCoreConnectionsPerHost(REMOTE)).isEqualTo(1);
     assertThat(poolingOptions.getMaxConnectionsPerHost(REMOTE)).isEqualTo(1);
     assertThat(poolingOptions.getMaxRequestsPerConnection(LOCAL)).isEqualTo(32768);

--- a/manual/application.template.conf
+++ b/manual/application.template.conf
@@ -775,8 +775,8 @@ dsbulk {
 
     # The number of connections in the pool for nodes at "local" distance.
     # Type: number
-    # Default value: 4
-    #driver.pooling.local.connections = 4
+    # Default value: 8
+    #driver.pooling.local.connections = 8
 
     # The maximum number of requests (1 to 32768) that can be executed concurrently on a connection.
     # Type: number

--- a/manual/settings.md
+++ b/manual/settings.md
@@ -868,7 +868,7 @@ Default: **"30 seconds"**.
 
 The number of connections in the pool for nodes at "local" distance.
 
-Default: **4**.
+Default: **8**.
 
 #### --driver.pooling.local.requests _&lt;number&gt;_
 


### PR DESCRIPTION
Would like to test this a little with multi-node clusters to ensure it doesn't have a negative impact (i doubt it will, but good to test!).