### PR TITLE
DAT-226: Use Netty's FastThreadLocal

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -8,6 +8,7 @@
 - [improvement] DAT-108: Upgrade DSE driver to 1.6.3.
 - [improvement] DAT-227: Warn that continuous paging is not available when unloading with CL > ONE.
 - [new feature] DAT-224: Add support for numeric overflow and rounding.
+- [improvement] DAT-226: Use Netty's FastThreadLocal.
 
 
 ### 1.0.0-rc1

--- a/connectors/csv/pom.xml
+++ b/connectors/csv/pom.xml
@@ -44,8 +44,8 @@
     </dependency>
 
     <dependency>
-      <groupId>com.github.chrisvest</groupId>
-      <artifactId>stormpot</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-common</artifactId>
     </dependency>
 
     <dependency>

--- a/connectors/json/pom.xml
+++ b/connectors/json/pom.xml
@@ -49,8 +49,8 @@
     </dependency>
 
     <dependency>
-      <groupId>com.github.chrisvest</groupId>
-      <artifactId>stormpot</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-common</artifactId>
     </dependency>
 
     <dependency>

--- a/connectors/json/src/test/java/com/datastax/dsbulk/connectors/json/JsonConnectorTest.java
+++ b/connectors/json/src/test/java/com/datastax/dsbulk/connectors/json/JsonConnectorTest.java
@@ -48,7 +48,6 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 
-/** */
 @SuppressWarnings("Duplicates")
 class JsonConnectorTest {
 
@@ -198,7 +197,15 @@ class JsonConnectorTest {
       connector.configure(settings, false);
       connector.init();
       assertThat(connector.isWriteToStandardOutput()).isTrue();
-      Flux.<Record>just(new DefaultRecord(null, null, -1, null, "fóô", "bàr", "qïx"))
+      Flux.<Record>just(
+          new DefaultRecord(
+              null,
+              null,
+              -1,
+              null,
+              factory.textNode("fóô"),
+              factory.textNode("bàr"),
+              factory.textNode("qïx")))
           .transform(connector.write())
           .blockLast();
       assertThat(new String(baos.toByteArray(), "ISO-8859-1"))

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -114,6 +114,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-common</artifactId>
+    </dependency>
+    
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/engine/src/main/java/com/datastax/dsbulk/engine/UnloadWorkflow.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/UnloadWorkflow.java
@@ -35,6 +35,7 @@ import com.datastax.dsbulk.engine.internal.settings.SettingsManager;
 import com.datastax.dsbulk.engine.internal.utils.WorkflowUtils;
 import com.datastax.dsbulk.executor.reactor.reader.ReactorBulkReader;
 import com.google.common.base.Stopwatch;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.jetbrains.annotations.NotNull;
@@ -95,7 +96,9 @@ public class UnloadWorkflow implements Workflow {
     monitoringSettings.init();
     executorSettings.init();
     driverSettings.init();
-    scheduler = Schedulers.newParallel("workflow");
+    scheduler =
+        Schedulers.newParallel(
+            Runtime.getRuntime().availableProcessors(), new DefaultThreadFactory("workflow"));
     cluster = driverSettings.newCluster();
     String keyspace = schemaSettings.getKeyspace();
     DseSession session = cluster.connect(keyspace);

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/ExtendedCodecRegistry.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/ExtendedCodecRegistry.java
@@ -79,6 +79,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.reflect.TypeToken;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
@@ -111,7 +112,7 @@ public class ExtendedCodecRegistry {
   private final Map<String, Boolean> booleanInputWords;
   private final Map<Boolean, String> booleanOutputWords;
   private final List<BigDecimal> booleanNumbers;
-  private final ThreadLocal<NumberFormat> numberFormat;
+  private final FastThreadLocal<NumberFormat> numberFormat;
   private final OverflowStrategy overflowStrategy;
   private final RoundingMode roundingMode;
   private final DateTimeFormatter localDateFormat;
@@ -127,7 +128,7 @@ public class ExtendedCodecRegistry {
       Map<String, Boolean> booleanInputWords,
       Map<Boolean, String> booleanOutputWords,
       List<BigDecimal> booleanNumbers,
-      ThreadLocal<NumberFormat> numberFormat,
+      FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
       DateTimeFormatter localDateFormat,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBigDecimalCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBigDecimalCodec.java
@@ -13,6 +13,7 @@ import com.datastax.dsbulk.engine.internal.codecs.util.CodecUtils;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
@@ -25,7 +26,7 @@ import java.util.concurrent.TimeUnit;
 public class JsonNodeToBigDecimalCodec extends JsonNodeToNumberCodec<BigDecimal> {
 
   public JsonNodeToBigDecimalCodec(
-      ThreadLocal<NumberFormat> numberFormat,
+      FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
       DateTimeFormatter temporalFormat,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBigIntegerCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBigIntegerCodec.java
@@ -14,6 +14,7 @@ import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
@@ -27,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 public class JsonNodeToBigIntegerCodec extends JsonNodeToNumberCodec<BigInteger> {
 
   public JsonNodeToBigIntegerCodec(
-      ThreadLocal<NumberFormat> numberFormat,
+      FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
       DateTimeFormatter temporalFormat,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToByteCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToByteCodec.java
@@ -14,6 +14,7 @@ import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
@@ -26,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 public class JsonNodeToByteCodec extends JsonNodeToNumberCodec<Byte> {
 
   public JsonNodeToByteCodec(
-      ThreadLocal<NumberFormat> numberFormat,
+      FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
       DateTimeFormatter temporalFormat,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToDoubleCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToDoubleCodec.java
@@ -14,6 +14,7 @@ import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
@@ -26,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 public class JsonNodeToDoubleCodec extends JsonNodeToNumberCodec<Double> {
 
   public JsonNodeToDoubleCodec(
-      ThreadLocal<NumberFormat> numberFormat,
+      FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
       DateTimeFormatter temporalFormat,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToFloatCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToFloatCodec.java
@@ -14,6 +14,7 @@ import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
@@ -26,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 public class JsonNodeToFloatCodec extends JsonNodeToNumberCodec<Float> {
 
   public JsonNodeToFloatCodec(
-      ThreadLocal<NumberFormat> numberFormat,
+      FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
       DateTimeFormatter temporalFormat,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToInstantCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToInstantCodec.java
@@ -11,6 +11,7 @@ package com.datastax.dsbulk.engine.internal.codecs.json;
 import com.datastax.driver.extras.codecs.jdk8.InstantCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.CodecUtils;
 import com.fasterxml.jackson.databind.JsonNode;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.text.NumberFormat;
 import java.time.Instant;
 import java.time.ZonedDateTime;
@@ -20,13 +21,13 @@ import java.util.concurrent.TimeUnit;
 
 public class JsonNodeToInstantCodec extends JsonNodeToTemporalCodec<Instant> {
 
-  private final ThreadLocal<NumberFormat> numberFormat;
+  private final FastThreadLocal<NumberFormat> numberFormat;
   private final TimeUnit timeUnit;
   private final ZonedDateTime epoch;
 
   public JsonNodeToInstantCodec(
       DateTimeFormatter temporalFormat,
-      ThreadLocal<NumberFormat> numberFormat,
+      FastThreadLocal<NumberFormat> numberFormat,
       TimeUnit timeUnit,
       ZonedDateTime epoch) {
     super(InstantCodec.instance, temporalFormat);

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToIntegerCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToIntegerCodec.java
@@ -14,6 +14,7 @@ import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
@@ -26,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 public class JsonNodeToIntegerCodec extends JsonNodeToNumberCodec<Integer> {
 
   public JsonNodeToIntegerCodec(
-      ThreadLocal<NumberFormat> numberFormat,
+      FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
       DateTimeFormatter temporalFormat,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToLongCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToLongCodec.java
@@ -14,6 +14,7 @@ import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
@@ -26,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 public class JsonNodeToLongCodec extends JsonNodeToNumberCodec<Long> {
 
   public JsonNodeToLongCodec(
-      ThreadLocal<NumberFormat> numberFormat,
+      FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
       DateTimeFormatter temporalFormat,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToNumberCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToNumberCodec.java
@@ -13,6 +13,7 @@ import com.datastax.dsbulk.engine.internal.codecs.ConvertingCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.CodecUtils;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.fasterxml.jackson.databind.JsonNode;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
 import java.time.ZonedDateTime;
@@ -23,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 
 abstract class JsonNodeToNumberCodec<N extends Number> extends ConvertingCodec<JsonNode, N> {
 
-  private final ThreadLocal<NumberFormat> numberFormat;
+  private final FastThreadLocal<NumberFormat> numberFormat;
   private final OverflowStrategy overflowStrategy;
   private final RoundingMode roundingMode;
   private final DateTimeFormatter temporalFormat;
@@ -34,7 +35,7 @@ abstract class JsonNodeToNumberCodec<N extends Number> extends ConvertingCodec<J
 
   JsonNodeToNumberCodec(
       TypeCodec<N> targetCodec,
-      ThreadLocal<NumberFormat> numberFormat,
+      FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
       DateTimeFormatter temporalFormat,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToShortCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToShortCodec.java
@@ -13,6 +13,7 @@ import static java.util.stream.Collectors.toList;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
@@ -25,7 +26,7 @@ import java.util.concurrent.TimeUnit;
 public class JsonNodeToShortCodec extends JsonNodeToNumberCodec<Short> {
 
   public JsonNodeToShortCodec(
-      ThreadLocal<NumberFormat> numberFormat,
+      FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
       DateTimeFormatter temporalFormat,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBigDecimalCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBigDecimalCodec.java
@@ -11,6 +11,7 @@ package com.datastax.dsbulk.engine.internal.codecs.string;
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.CodecUtils;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
@@ -23,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 public class StringToBigDecimalCodec extends StringToNumberCodec<BigDecimal> {
 
   public StringToBigDecimalCodec(
-      ThreadLocal<NumberFormat> numberFormat,
+      FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
       DateTimeFormatter temporalFormat,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBigIntegerCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBigIntegerCodec.java
@@ -12,6 +12,7 @@ import static java.util.stream.Collectors.toList;
 
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
@@ -25,7 +26,7 @@ import java.util.concurrent.TimeUnit;
 public class StringToBigIntegerCodec extends StringToNumberCodec<BigInteger> {
 
   public StringToBigIntegerCodec(
-      ThreadLocal<NumberFormat> numberFormat,
+      FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
       DateTimeFormatter temporalFormat,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToByteCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToByteCodec.java
@@ -12,6 +12,7 @@ import static java.util.stream.Collectors.toList;
 
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
@@ -24,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 public class StringToByteCodec extends StringToNumberCodec<Byte> {
 
   public StringToByteCodec(
-      ThreadLocal<NumberFormat> numberFormat,
+      FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
       DateTimeFormatter temporalFormat,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToDoubleCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToDoubleCodec.java
@@ -12,6 +12,7 @@ import static java.util.stream.Collectors.toList;
 
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
@@ -24,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 public class StringToDoubleCodec extends StringToNumberCodec<Double> {
 
   public StringToDoubleCodec(
-      ThreadLocal<NumberFormat> numberFormat,
+      FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
       DateTimeFormatter temporalFormat,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToFloatCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToFloatCodec.java
@@ -12,6 +12,7 @@ import static java.util.stream.Collectors.toList;
 
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
@@ -24,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 public class StringToFloatCodec extends StringToNumberCodec<Float> {
 
   public StringToFloatCodec(
-      ThreadLocal<NumberFormat> numberFormat,
+      FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
       DateTimeFormatter temporalFormat,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToInstantCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToInstantCodec.java
@@ -10,6 +10,7 @@ package com.datastax.dsbulk.engine.internal.codecs.string;
 
 import com.datastax.driver.extras.codecs.jdk8.InstantCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.CodecUtils;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.text.NumberFormat;
 import java.time.Instant;
 import java.time.ZonedDateTime;
@@ -19,13 +20,13 @@ import java.util.concurrent.TimeUnit;
 
 public class StringToInstantCodec extends StringToTemporalCodec<Instant> {
 
-  private final ThreadLocal<NumberFormat> numberFormat;
+  private final FastThreadLocal<NumberFormat> numberFormat;
   private final TimeUnit timeUnit;
   private final ZonedDateTime epoch;
 
   public StringToInstantCodec(
       DateTimeFormatter temporalFormat,
-      ThreadLocal<NumberFormat> numberFormat,
+      FastThreadLocal<NumberFormat> numberFormat,
       TimeUnit timeUnit,
       ZonedDateTime epoch) {
     super(InstantCodec.instance, temporalFormat);

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToIntegerCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToIntegerCodec.java
@@ -12,6 +12,7 @@ import static java.util.stream.Collectors.toList;
 
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
@@ -24,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 public class StringToIntegerCodec extends StringToNumberCodec<Integer> {
 
   public StringToIntegerCodec(
-      ThreadLocal<NumberFormat> numberFormat,
+      FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
       DateTimeFormatter temporalFormat,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToLongCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToLongCodec.java
@@ -12,6 +12,7 @@ import static java.util.stream.Collectors.toList;
 
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
@@ -24,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 public class StringToLongCodec extends StringToNumberCodec<Long> {
 
   public StringToLongCodec(
-      ThreadLocal<NumberFormat> numberFormat,
+      FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
       DateTimeFormatter temporalFormat,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToNumberCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToNumberCodec.java
@@ -12,6 +12,7 @@ import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.ConvertingCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.CodecUtils;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
 import java.time.ZonedDateTime;
@@ -22,7 +23,7 @@ import java.util.concurrent.TimeUnit;
 
 public abstract class StringToNumberCodec<N extends Number> extends ConvertingCodec<String, N> {
 
-  private final ThreadLocal<NumberFormat> numberFormat;
+  private final FastThreadLocal<NumberFormat> numberFormat;
   private final OverflowStrategy overflowStrategy;
   private final RoundingMode roundingMode;
   private final DateTimeFormatter temporalFormat;
@@ -33,7 +34,7 @@ public abstract class StringToNumberCodec<N extends Number> extends ConvertingCo
 
   StringToNumberCodec(
       TypeCodec<N> targetCodec,
-      ThreadLocal<NumberFormat> numberFormat,
+      FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
       DateTimeFormatter temporalFormat,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToShortCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToShortCodec.java
@@ -11,6 +11,7 @@ package com.datastax.dsbulk.engine.internal.codecs.string;
 import static java.util.stream.Collectors.toList;
 
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
@@ -23,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 public class StringToShortCodec extends StringToNumberCodec<Short> {
 
   public StringToShortCodec(
-      ThreadLocal<NumberFormat> numberFormat,
+      FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
       DateTimeFormatter temporalFormat,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/log/LogManager.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/log/LogManager.java
@@ -41,6 +41,7 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Range;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URI;
@@ -117,7 +118,7 @@ public class LogManager implements AutoCloseable {
     this(
         workflowType,
         cluster,
-        Schedulers.newParallel("log-manager", 4),
+        Schedulers.newParallel(4, new DefaultThreadFactory("log-manager")),
         executionDirectory,
         maxErrors,
         maxErrorRatio,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/settings/EngineSettings.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/settings/EngineSettings.java
@@ -12,7 +12,6 @@ import com.datastax.dsbulk.commons.config.LoaderConfig;
 import com.datastax.dsbulk.commons.internal.config.ConfigUtils;
 import com.typesafe.config.ConfigException;
 
-/** */
 public class EngineSettings {
 
   private static final String DRY_RUN = "dryRun";

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBigDecimalCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBigDecimalCodecTest.java
@@ -23,6 +23,7 @@ import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.google.common.collect.ImmutableMap;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
@@ -30,8 +31,8 @@ import org.junit.jupiter.api.Test;
 
 class JsonNodeToBigDecimalCodecTest {
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private final JsonNodeToBigDecimalCodec codec =
       new JsonNodeToBigDecimalCodec(

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBigIntegerCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBigIntegerCodecTest.java
@@ -23,6 +23,7 @@ import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.google.common.collect.ImmutableMap;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
@@ -30,8 +31,8 @@ import org.junit.jupiter.api.Test;
 
 class JsonNodeToBigIntegerCodecTest {
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private final JsonNodeToBigIntegerCodec codec =
       new JsonNodeToBigIntegerCodec(

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToByteCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToByteCodecTest.java
@@ -23,20 +23,20 @@ import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.google.common.collect.ImmutableMap;
-import java.math.RoundingMode;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.text.NumberFormat;
 import org.junit.jupiter.api.Test;
 
 class JsonNodeToByteCodecTest {
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private final JsonNodeToByteCodec codec =
       new JsonNodeToByteCodec(
           numberFormat,
           OverflowStrategy.REJECT,
-          RoundingMode.HALF_EVEN,
+          HALF_EVEN,
           CQL_DATE_TIME_FORMAT,
           MILLISECONDS,
           EPOCH.atZone(UTC),

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToDoubleCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToDoubleCodecTest.java
@@ -23,14 +23,15 @@ import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.google.common.collect.ImmutableMap;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
 import org.junit.jupiter.api.Test;
 
 class JsonNodeToDoubleCodecTest {
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private final JsonNodeToDoubleCodec codec =
       new JsonNodeToDoubleCodec(

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToFloatCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToFloatCodecTest.java
@@ -23,14 +23,15 @@ import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.google.common.collect.ImmutableMap;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
 import org.junit.jupiter.api.Test;
 
 class JsonNodeToFloatCodecTest {
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private final JsonNodeToFloatCodec codec =
       new JsonNodeToFloatCodec(

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToInstantCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToInstantCodecTest.java
@@ -19,6 +19,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.text.NumberFormat;
 import java.time.Duration;
 import java.time.Instant;
@@ -37,8 +38,8 @@ class JsonNodeToInstantCodecTest {
   private final DateTimeFormatter temporalFormat2 =
       CodecSettings.getDateTimeFormat("yyyyMMddHHmmss", UTC, US, EPOCH.atZone(UTC));
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   @Test
   void should_convert_from_valid_input() {

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToIntegerCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToIntegerCodecTest.java
@@ -23,14 +23,15 @@ import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.google.common.collect.ImmutableMap;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
 import org.junit.jupiter.api.Test;
 
 class JsonNodeToIntegerCodecTest {
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private final JsonNodeToIntegerCodec codec =
       new JsonNodeToIntegerCodec(

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToListCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToListCodecTest.java
@@ -27,6 +27,7 @@ import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
 import java.util.List;
@@ -36,8 +37,8 @@ class JsonNodeToListCodecTest {
 
   private final ObjectMapper objectMapper = CodecSettings.getObjectMapper();
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private final JsonNodeToDoubleCodec eltCodec1 =
       new JsonNodeToDoubleCodec(

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToLongCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToLongCodecTest.java
@@ -23,14 +23,15 @@ import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.google.common.collect.ImmutableMap;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
 import org.junit.jupiter.api.Test;
 
 class JsonNodeToLongCodecTest {
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private final JsonNodeToLongCodec codec =
       new JsonNodeToLongCodec(

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToMapCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToMapCodecTest.java
@@ -26,6 +26,7 @@ import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
 import java.util.Arrays;
@@ -38,8 +39,8 @@ class JsonNodeToMapCodecTest {
 
   private final ObjectMapper objectMapper = CodecSettings.getObjectMapper();
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private final ConvertingCodec<String, Double> keyCodec =
       new StringToDoubleCodec(

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToSetCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToSetCodecTest.java
@@ -28,6 +28,7 @@ import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
 import java.util.Set;
@@ -37,8 +38,8 @@ class JsonNodeToSetCodecTest {
 
   private final ObjectMapper objectMapper = CodecSettings.getObjectMapper();
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private final JsonNodeToDoubleCodec eltCodec1 =
       new JsonNodeToDoubleCodec(

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToShortCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToShortCodecTest.java
@@ -23,14 +23,15 @@ import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.google.common.collect.ImmutableMap;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
 import org.junit.jupiter.api.Test;
 
 class JsonNodeToShortCodecTest {
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private final JsonNodeToShortCodec codec =
       new JsonNodeToShortCodec(

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToTupleCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToTupleCodecTest.java
@@ -29,6 +29,7 @@ import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.text.NumberFormat;
 import java.time.Instant;
 import java.util.List;
@@ -38,8 +39,8 @@ class JsonNodeToTupleCodecTest {
 
   private final ObjectMapper objectMapper = CodecSettings.getObjectMapper();
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private final CodecRegistry codecRegistry = new CodecRegistry().register(InstantCodec.instance);
 

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToUDTCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToUDTCodecTest.java
@@ -39,6 +39,7 @@ import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
 import java.time.LocalDate;
@@ -54,8 +55,8 @@ class JsonNodeToUDTCodecTest {
 
   private final CodecRegistry codecRegistry = new CodecRegistry().register(LocalDateCodec.instance);
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   // UDT 1
 

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToUUIDCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToUUIDCodecTest.java
@@ -25,6 +25,7 @@ import com.datastax.driver.core.utils.UUIDs;
 import com.datastax.dsbulk.engine.internal.codecs.string.StringToInstantCodec;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.text.NumberFormat;
 import java.time.ZonedDateTime;
 import java.util.UUID;
@@ -33,8 +34,8 @@ import org.junit.jupiter.api.Test;
 
 class JsonNodeToUUIDCodecTest {
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private StringToInstantCodec instantCodec =
       new StringToInstantCodec(CQL_DATE_TIME_FORMAT, numberFormat, MILLISECONDS, EPOCH.atZone(UTC));

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBigDecimalCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBigDecimalCodecTest.java
@@ -22,6 +22,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.google.common.collect.ImmutableMap;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
@@ -29,8 +30,8 @@ import org.junit.jupiter.api.Test;
 
 class StringToBigDecimalCodecTest {
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private final StringToBigDecimalCodec codec =
       new StringToBigDecimalCodec(

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBigIntegerCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBigIntegerCodecTest.java
@@ -22,6 +22,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.google.common.collect.ImmutableMap;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
@@ -29,8 +30,8 @@ import org.junit.jupiter.api.Test;
 
 class StringToBigIntegerCodecTest {
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private final StringToBigIntegerCodec codec =
       new StringToBigIntegerCodec(

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToByteCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToByteCodecTest.java
@@ -22,14 +22,15 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.google.common.collect.ImmutableMap;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
 import org.junit.jupiter.api.Test;
 
 class StringToByteCodecTest {
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private final StringToByteCodec codec =
       new StringToByteCodec(

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToDoubleCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToDoubleCodecTest.java
@@ -22,14 +22,15 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.google.common.collect.ImmutableMap;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
 import org.junit.jupiter.api.Test;
 
 class StringToDoubleCodecTest {
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private final StringToDoubleCodec codec =
       new StringToDoubleCodec(

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToFloatCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToFloatCodecTest.java
@@ -22,14 +22,15 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.google.common.collect.ImmutableMap;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
 import org.junit.jupiter.api.Test;
 
 class StringToFloatCodecTest {
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private final StringToFloatCodec codec =
       new StringToFloatCodec(

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToInstantCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToInstantCodecTest.java
@@ -17,6 +17,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.text.NumberFormat;
 import java.time.Duration;
 import java.time.Instant;
@@ -35,8 +36,8 @@ class StringToInstantCodecTest {
   private final DateTimeFormatter temporalFormat2 =
       CodecSettings.getDateTimeFormat("yyyyMMddHHmmss", UTC, US, EPOCH.atZone(UTC));
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   @Test
   void should_convert_from_valid_input() {

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToIntegerCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToIntegerCodecTest.java
@@ -22,14 +22,15 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.google.common.collect.ImmutableMap;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
 import org.junit.jupiter.api.Test;
 
 class StringToIntegerCodecTest {
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private final StringToIntegerCodec codec =
       new StringToIntegerCodec(

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToListCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToListCodecTest.java
@@ -30,6 +30,7 @@ import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
 import java.util.List;
@@ -39,8 +40,8 @@ class StringToListCodecTest {
 
   private final ObjectMapper objectMapper = CodecSettings.getObjectMapper();
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private final JsonNodeToDoubleCodec eltCodec1 =
       new JsonNodeToDoubleCodec(

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToLongCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToLongCodecTest.java
@@ -22,14 +22,15 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.google.common.collect.ImmutableMap;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
 import org.junit.jupiter.api.Test;
 
 class StringToLongCodecTest {
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private final StringToLongCodec codec =
       new StringToLongCodec(

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToMapCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToMapCodecTest.java
@@ -29,6 +29,7 @@ import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
 import java.util.Arrays;
@@ -41,8 +42,8 @@ class StringToMapCodecTest {
 
   private final ObjectMapper objectMapper = CodecSettings.getObjectMapper();
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private final StringToDoubleCodec keyCodec =
       new StringToDoubleCodec(

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToSetCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToSetCodecTest.java
@@ -31,6 +31,7 @@ import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
 import java.util.Set;
@@ -40,8 +41,8 @@ class StringToSetCodecTest {
 
   private final ObjectMapper objectMapper = CodecSettings.getObjectMapper();
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private final JsonNodeToDoubleCodec eltCodec1 =
       new JsonNodeToDoubleCodec(

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToShortCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToShortCodecTest.java
@@ -22,14 +22,15 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.google.common.collect.ImmutableMap;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
 import org.junit.jupiter.api.Test;
 
 class StringToShortCodecTest {
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private final StringToShortCodec codec =
       new StringToShortCodec(

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToTupleCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToTupleCodecTest.java
@@ -32,6 +32,7 @@ import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.text.NumberFormat;
 import java.time.Instant;
 import java.util.List;
@@ -41,8 +42,8 @@ class StringToTupleCodecTest {
 
   private final ObjectMapper objectMapper = CodecSettings.getObjectMapper();
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private final CodecRegistry codecRegistry = new CodecRegistry().register(InstantCodec.instance);
 

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToUDTCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToUDTCodecTest.java
@@ -44,6 +44,7 @@ import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
 import java.time.LocalDate;
@@ -59,8 +60,8 @@ class StringToUDTCodecTest {
 
   private final CodecRegistry codecRegistry = new CodecRegistry().register(LocalDateCodec.instance);
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   // UDT 1
 

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToUUIDCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToUUIDCodecTest.java
@@ -23,6 +23,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.driver.core.utils.UUIDs;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.text.NumberFormat;
 import java.time.ZonedDateTime;
 import java.util.UUID;
@@ -30,8 +31,8 @@ import org.junit.jupiter.api.Test;
 
 class StringToUUIDCodecTest {
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   private StringToInstantCodec instantCodec =
       new StringToInstantCodec(CQL_DATE_TIME_FORMAT, numberFormat, MILLISECONDS, EPOCH.atZone(UTC));

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/util/CodecUtilsTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/util/CodecUtilsTest.java
@@ -105,9 +105,11 @@ class CodecUtilsTest {
   private final DateTimeFormatter localTimeFormat =
       CodecSettings.getDateTimeFormat("ISO_LOCAL_TIME", UTC, US, EPOCH.atZone(UTC));
 
-  private Map<String, Boolean> booleanInputWords = ImmutableMap.of("true", true, "false", false);
+  private final Map<String, Boolean> booleanInputWords =
+      ImmutableMap.of("true", true, "false", false);
 
-  private List<BigDecimal> booleanNumbers = Lists.newArrayList(BigDecimal.ONE, BigDecimal.ZERO);
+  private final List<BigDecimal> booleanNumbers =
+      Lists.newArrayList(BigDecimal.ONE, BigDecimal.ZERO);
 
   @SuppressWarnings("ConstantConditions")
   @Test
@@ -945,7 +947,7 @@ class CodecUtilsTest {
     StringToInstantCodec instantCodec =
         new StringToInstantCodec(
             timestampFormat1,
-            ThreadLocal.withInitial(() -> this.numberFormat1),
+            CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true),
             MILLISECONDS,
             EPOCH.atZone(UTC));
     assertThat(CodecUtils.parseUUID(null, instantCodec, MIN)).isNull();

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/writetime/WriteTimeCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/writetime/WriteTimeCodecTest.java
@@ -21,6 +21,7 @@ import com.datastax.dsbulk.engine.internal.codecs.temporal.DateToTemporalCodec;
 import com.datastax.dsbulk.engine.internal.codecs.temporal.TemporalToTemporalCodec;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.sql.Timestamp;
 import java.text.NumberFormat;
 import java.time.Instant;
@@ -39,8 +40,8 @@ class WriteTimeCodecTest {
   private final DateTimeFormatter temporalFormat =
       CodecSettings.getDateTimeFormat("CQL_DATE_TIME", UTC, US, epoch);
 
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   @Test
   void should_convert_to_timestamp_micros() {

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/schema/DefaultRecordMapperTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/schema/DefaultRecordMapperTest.java
@@ -46,7 +46,7 @@ import com.datastax.dsbulk.engine.internal.statement.UnmappableStatement;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.TypeToken;
-import java.math.RoundingMode;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.net.URI;
 import java.text.NumberFormat;
 import java.time.Instant;
@@ -84,8 +84,8 @@ class DefaultRecordMapperTest {
   private ArgumentCaptor<Object> valueCaptor;
   private ArgumentCaptor<TypeCodec> codecCaptor;
   private RecordMetadata recordMetadata;
-  private final ThreadLocal<NumberFormat> formatter =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> formatter =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
   @BeforeEach
   void setUp() {
@@ -163,7 +163,7 @@ class DefaultRecordMapperTest {
             new StringToLongCodec(
                 formatter,
                 OverflowStrategy.REJECT,
-                RoundingMode.HALF_EVEN,
+                HALF_EVEN,
                 CQL_DATE_TIME_FORMAT,
                 MINUTES,
                 EPOCH.atZone(UTC),
@@ -195,7 +195,7 @@ class DefaultRecordMapperTest {
             new StringToLongCodec(
                 formatter,
                 OverflowStrategy.REJECT,
-                RoundingMode.HALF_EVEN,
+                HALF_EVEN,
                 CQL_DATE_TIME_FORMAT,
                 MINUTES,
                 millennium.atZone(UTC),
@@ -225,7 +225,7 @@ class DefaultRecordMapperTest {
             new StringToLongCodec(
                 formatter,
                 OverflowStrategy.REJECT,
-                RoundingMode.HALF_EVEN,
+                HALF_EVEN,
                 CQL_DATE_TIME_FORMAT,
                 MILLISECONDS,
                 EPOCH.atZone(UTC),
@@ -257,7 +257,7 @@ class DefaultRecordMapperTest {
             new StringToLongCodec(
                 formatter,
                 OverflowStrategy.REJECT,
-                RoundingMode.HALF_EVEN,
+                HALF_EVEN,
                 timestampFormat,
                 MILLISECONDS,
                 EPOCH.atZone(UTC),

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/settings/SchemaSettingsTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/settings/SchemaSettingsTest.java
@@ -49,6 +49,7 @@ import com.datastax.dsbulk.engine.internal.schema.ReadResultMapper;
 import com.datastax.dsbulk.engine.internal.schema.RecordMapper;
 import com.google.common.collect.Lists;
 import com.typesafe.config.ConfigFactory;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.text.NumberFormat;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -81,8 +82,8 @@ class SchemaSettingsTest {
 
   private final ExtendedCodecRegistry codecRegistry = mock(ExtendedCodecRegistry.class);
   private final RecordMetadata recordMetadata = new SchemaFreeRecordMetadata();
-  private final ThreadLocal<NumberFormat> numberFormat =
-      ThreadLocal.withInitial(() -> CodecSettings.getNumberFormat("#,###.##", US, HALF_EVEN, true));
+  private final FastThreadLocal<NumberFormat> numberFormat =
+      CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
   private final StringToInstantCodec codec =
       new StringToInstantCodec(CQL_DATE_TIME_FORMAT, numberFormat, MILLISECONDS, EPOCH.atZone(UTC));
 

--- a/pom.xml
+++ b/pom.xml
@@ -295,12 +295,6 @@
       </dependency>
 
       <dependency>
-        <groupId>com.github.chrisvest</groupId>
-        <artifactId>stormpot</artifactId>
-        <version>2.4.1</version>
-      </dependency>
-
-      <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-api</artifactId>
         <version>${junit.version}</version>


### PR DESCRIPTION
I couldn't find a simple way to test that we are indeed benefiting from FastThreadLocal's goodness, but I did validate manually that our threads are all FastThreads, which means that the optimization can kick in.