### PR TITLE
DAT-266: DSE Geometry types cause CodecNotFoundException

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -8,6 +8,7 @@
 - [improvement] DAT-251: Update DriverSettings with new TokenAwarePolicy.
 - [bug] DAT-259: LogManager files have interleaved entries.
 - [bug] DAT-260: LogManager is closing files too soon.
+- [bug] DAT-266: DSE Geometry types cause CodecNotFoundException.
 
 
 ### 1.0.1

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeConvertingCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeConvertingCodec.java
@@ -13,16 +13,16 @@ import com.datastax.dsbulk.engine.internal.codecs.ConvertingCodec;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
 
-abstract class JsonNodeConvertingCodec<T> extends ConvertingCodec<JsonNode, T> {
+public abstract class JsonNodeConvertingCodec<T> extends ConvertingCodec<JsonNode, T> {
 
   private final List<String> nullStrings;
 
-  JsonNodeConvertingCodec(TypeCodec<T> targetCodec, List<String> nullStrings) {
+  protected JsonNodeConvertingCodec(TypeCodec<T> targetCodec, List<String> nullStrings) {
     super(targetCodec, JsonNode.class);
     this.nullStrings = nullStrings;
   }
 
-  boolean isNull(JsonNode node) {
+  protected boolean isNull(JsonNode node) {
     return node == null
         || node.isNull()
         || (node.isValueNode() && nullStrings.contains(node.asText()));

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBlobCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBlobCodec.java
@@ -13,6 +13,7 @@ import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NO
 import com.datastax.driver.core.utils.Bytes;
 import com.datastax.dsbulk.engine.internal.codecs.util.CodecUtils;
 import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 
@@ -26,6 +27,13 @@ public class JsonNodeToBlobCodec extends JsonNodeConvertingCodec<ByteBuffer> {
   public ByteBuffer externalToInternal(JsonNode node) {
     if (isNull(node)) {
       return null;
+    }
+    if (node.isBinary()) {
+      try {
+        return ByteBuffer.wrap(node.binaryValue());
+      } catch (IOException ignored) {
+        // try as a string below
+      }
     }
     String s = node.asText();
     return CodecUtils.parseByteBuffer(s);

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBooleanCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBooleanCodec.java
@@ -33,9 +33,6 @@ public class JsonNodeToBooleanCodec extends JsonNodeConvertingCodec<Boolean> {
       return node.asBoolean();
     }
     String s = node.asText();
-    if (s == null || s.isEmpty()) {
-      return null;
-    }
     Boolean b = inputs.get(s.toLowerCase());
     if (b == null) {
       throw new InvalidTypeException("Invalid boolean value: " + s);

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToDurationCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToDurationCodec.java
@@ -26,16 +26,13 @@ public class JsonNodeToDurationCodec extends JsonNodeConvertingCodec<Duration> {
       return null;
     }
     String s = node.asText();
-    if (s == null || s.isEmpty()) {
-      return null;
-    }
     return Duration.from(s);
   }
 
   @Override
   public JsonNode internalToExternal(Duration value) {
     if (value == null) {
-      return null;
+      return JSON_NODE_FACTORY.nullNode();
     }
     return JSON_NODE_FACTORY.textNode(value.toString());
   }

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToInetAddressCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToInetAddressCodec.java
@@ -27,8 +27,8 @@ public class JsonNodeToInetAddressCodec extends JsonNodeConvertingCodec<InetAddr
       return null;
     }
     String s = node.asText();
-    if (s == null || s.isEmpty()) {
-      return null;
+    if (s.isEmpty()) {
+      throw new InvalidTypeException("Cannot create inet address from empty string");
     }
     try {
       return InetAddress.getByName(s);

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToStringCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToStringCodec.java
@@ -11,13 +11,21 @@ package com.datastax.dsbulk.engine.internal.codecs.json;
 import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
 
 import com.datastax.driver.core.TypeCodec;
+import com.datastax.driver.core.exceptions.InvalidTypeException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import java.util.List;
 
 public class JsonNodeToStringCodec extends JsonNodeConvertingCodec<String> {
 
-  public JsonNodeToStringCodec(TypeCodec<String> innerCodec, List<String> nullStrings) {
+  private final ObjectMapper objectMapper;
+
+  public JsonNodeToStringCodec(
+      TypeCodec<String> innerCodec, ObjectMapper objectMapper, List<String> nullStrings) {
     super(innerCodec, nullStrings);
+    this.objectMapper = objectMapper;
   }
 
   @Override
@@ -25,14 +33,36 @@ public class JsonNodeToStringCodec extends JsonNodeConvertingCodec<String> {
     if (isNull(node)) {
       return null;
     }
-    return node.asText();
+    if (node.isContainerNode()) {
+      try {
+        return objectMapper.writeValueAsString(node);
+      } catch (JsonProcessingException e) {
+        throw new InvalidTypeException("Cannot deserialize node " + node, e);
+      }
+    } else {
+      return node.asText();
+    }
   }
 
   @Override
   public JsonNode internalToExternal(String value) {
     if (value == null) {
-      return null;
+      return JSON_NODE_FACTORY.nullNode();
     }
+    try {
+      // Try to read a valid json first (object, array, or numeric values),
+      // and fall back to a textual node if that fails.
+      JsonNode node = objectMapper.readTree(value);
+      // readTree() may mess with the original value if it's not a valid json object, array or
+      // number, so check that now. It may also mess with quoted strings, so exclude textual nodes
+      // as well.
+      if (node != null && !node.isNull() && !node.isTextual()) {
+        return node;
+      }
+    } catch (IOException ignored) {
+      // not a valid json at all
+    }
+    // As a last resort, return the value as a textual node
     return JSON_NODE_FACTORY.textNode(value);
   }
 }

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToUnknownTypeCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToUnknownTypeCodec.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.json;
+
+import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
+
+import com.datastax.driver.core.TypeCodec;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+
+public class JsonNodeToUnknownTypeCodec<T> extends JsonNodeConvertingCodec<T> {
+
+  public JsonNodeToUnknownTypeCodec(TypeCodec<T> targetCodec, List<String> nullStrings) {
+    super(targetCodec, nullStrings);
+  }
+
+  @Override
+  public T externalToInternal(JsonNode node) {
+    if (isNull(node)) {
+      return null;
+    }
+    return getInternalCodec().parse(node.asText());
+  }
+
+  @Override
+  public JsonNode internalToExternal(T o) {
+    if (o == null) {
+      return JSON_NODE_FACTORY.nullNode();
+    }
+    String s = getInternalCodec().format(o);
+    // most codecs usually format null/empty values using the CQL keyword "NULL",
+    // but some others may choose to return a null string.
+    if (s == null || s.equalsIgnoreCase("NULL")) {
+      return JSON_NODE_FACTORY.nullNode();
+    }
+    return JSON_NODE_FACTORY.textNode(s);
+  }
+}

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/dse/JsonNodeToDateRangeCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/dse/JsonNodeToDateRangeCodec.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.json.dse;
+
+import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
+
+import com.datastax.driver.dse.search.DateRange;
+import com.datastax.driver.dse.search.DateRangeCodec;
+import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeConvertingCodec;
+import com.datastax.dsbulk.engine.internal.codecs.util.CodecUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+
+public class JsonNodeToDateRangeCodec extends JsonNodeConvertingCodec<DateRange> {
+
+  public JsonNodeToDateRangeCodec(List<String> nullStrings) {
+    super(DateRangeCodec.INSTANCE, nullStrings);
+  }
+
+  @Override
+  public DateRange externalToInternal(JsonNode node) {
+    if (isNull(node)) {
+      return null;
+    }
+    return CodecUtils.parseDateRange(node.asText());
+  }
+
+  @Override
+  public JsonNode internalToExternal(DateRange value) {
+    if (value == null) {
+      return JSON_NODE_FACTORY.nullNode();
+    }
+    return JSON_NODE_FACTORY.textNode(value.toString());
+  }
+}

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/dse/JsonNodeToLineStringCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/dse/JsonNodeToLineStringCodec.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.json.dse;
+
+import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
+
+import com.datastax.driver.core.exceptions.InvalidTypeException;
+import com.datastax.driver.dse.geometry.LineString;
+import com.datastax.driver.dse.geometry.codecs.LineStringCodec;
+import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeConvertingCodec;
+import com.datastax.dsbulk.engine.internal.codecs.util.CodecUtils;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.List;
+
+public class JsonNodeToLineStringCodec extends JsonNodeConvertingCodec<LineString> {
+
+  private final ObjectMapper objectMapper;
+
+  public JsonNodeToLineStringCodec(ObjectMapper objectMapper, List<String> nullStrings) {
+    super(LineStringCodec.INSTANCE, nullStrings);
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public LineString externalToInternal(JsonNode node) {
+    if (isNull(node)) {
+      return null;
+    }
+    try {
+      // We accept:
+      // 1) String nodes containing WKT literals
+      // 2) String nodes containing Geo JSON documents
+      // 3) Json object nodes compliant with Geo JSON syntax
+      // We need to serialize the node to support #3 above
+      String s;
+      if (node.isObject()) {
+        s = objectMapper.writeValueAsString(node);
+      } else {
+        s = node.asText();
+      }
+      return CodecUtils.parseLineString(s);
+    } catch (JsonProcessingException e) {
+      throw new InvalidTypeException("Cannot deserialize node " + node, e);
+    }
+  }
+
+  @Override
+  public JsonNode internalToExternal(LineString value) {
+    if (value == null) {
+      return JSON_NODE_FACTORY.nullNode();
+    }
+    try {
+      // Since geo types have a standardized Json format,
+      // use that rather than WKT.
+      return objectMapper.readTree(value.asGeoJson());
+    } catch (IOException e) {
+      throw new InvalidTypeException("Cannot serialize value " + value, e);
+    }
+  }
+}

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/dse/JsonNodeToPointCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/dse/JsonNodeToPointCodec.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.json.dse;
+
+import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
+
+import com.datastax.driver.core.exceptions.InvalidTypeException;
+import com.datastax.driver.dse.geometry.Point;
+import com.datastax.driver.dse.geometry.codecs.PointCodec;
+import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeConvertingCodec;
+import com.datastax.dsbulk.engine.internal.codecs.util.CodecUtils;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.List;
+
+public class JsonNodeToPointCodec extends JsonNodeConvertingCodec<Point> {
+
+  private final ObjectMapper objectMapper;
+
+  public JsonNodeToPointCodec(ObjectMapper objectMapper, List<String> nullStrings) {
+    super(PointCodec.INSTANCE, nullStrings);
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public Point externalToInternal(JsonNode node) {
+    if (isNull(node)) {
+      return null;
+    }
+    try {
+      // We accept:
+      // 1) String nodes containing WKT literals
+      // 2) String nodes containing Geo JSON documents
+      // 3) Json object nodes compliant with Geo JSON syntax
+      // We need to serialize the node to support #3 above
+      String s;
+      if (node.isObject()) {
+        s = objectMapper.writeValueAsString(node);
+      } else {
+        s = node.asText();
+      }
+      return CodecUtils.parsePoint(s);
+    } catch (JsonProcessingException e) {
+      throw new InvalidTypeException("Cannot deserialize node " + node, e);
+    }
+  }
+
+  @Override
+  public JsonNode internalToExternal(Point value) {
+    if (value == null) {
+      return JSON_NODE_FACTORY.nullNode();
+    }
+    try {
+      // Since geo types have a standardized Json format,
+      // use that rather than WKT.
+      return objectMapper.readTree(value.asGeoJson());
+    } catch (IOException e) {
+      throw new InvalidTypeException("Cannot serialize value " + value, e);
+    }
+  }
+}

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/dse/JsonNodeToPolygonCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/dse/JsonNodeToPolygonCodec.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.json.dse;
+
+import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
+
+import com.datastax.driver.core.exceptions.InvalidTypeException;
+import com.datastax.driver.dse.geometry.Polygon;
+import com.datastax.driver.dse.geometry.codecs.PolygonCodec;
+import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeConvertingCodec;
+import com.datastax.dsbulk.engine.internal.codecs.util.CodecUtils;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.List;
+
+public class JsonNodeToPolygonCodec extends JsonNodeConvertingCodec<Polygon> {
+
+  private final ObjectMapper objectMapper;
+
+  public JsonNodeToPolygonCodec(ObjectMapper objectMapper, List<String> nullStrings) {
+    super(PolygonCodec.INSTANCE, nullStrings);
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public Polygon externalToInternal(JsonNode node) {
+    if (isNull(node)) {
+      return null;
+    }
+    try {
+      // We accept:
+      // 1) String nodes containing WKT literals
+      // 2) String nodes containing Geo JSON documents
+      // 3) Json object nodes compliant with Geo JSON syntax
+      // We need to serialize the node to support #3 above
+      String s;
+      if (node.isObject()) {
+        s = objectMapper.writeValueAsString(node);
+      } else {
+        s = node.asText();
+      }
+      return CodecUtils.parsePolygon(s);
+    } catch (JsonProcessingException e) {
+      throw new InvalidTypeException("Cannot deserialize node " + node, e);
+    }
+  }
+
+  @Override
+  public JsonNode internalToExternal(Polygon value) {
+    if (value == null) {
+      return JSON_NODE_FACTORY.nullNode();
+    }
+    try {
+      // Since geo types have a standardized Json format,
+      // use that rather than WKT.
+      return objectMapper.readTree(value.asGeoJson());
+    } catch (IOException e) {
+      throw new InvalidTypeException("Cannot serialize value " + value, e);
+    }
+  }
+}

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringConvertingCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringConvertingCodec.java
@@ -12,20 +12,20 @@ import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.ConvertingCodec;
 import java.util.List;
 
-abstract class StringConvertingCodec<T> extends ConvertingCodec<String, T> {
+public abstract class StringConvertingCodec<T> extends ConvertingCodec<String, T> {
 
   private final List<String> nullStrings;
 
-  StringConvertingCodec(TypeCodec<T> targetCodec, List<String> nullStrings) {
+  protected StringConvertingCodec(TypeCodec<T> targetCodec, List<String> nullStrings) {
     super(targetCodec, String.class);
     this.nullStrings = nullStrings;
   }
 
-  boolean isNull(String s) {
-    return s == null || s.isEmpty() || nullStrings.contains(s);
+  protected boolean isNull(String s) {
+    return s == null || nullStrings.contains(s);
   }
 
-  String nullString() {
-    return nullStrings.isEmpty() ? null : nullStrings.get(0);
+  protected String nullString() {
+    return nullStrings.isEmpty() ? "" : nullStrings.get(0);
   }
 }

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToInetAddressCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToInetAddressCodec.java
@@ -23,6 +23,9 @@ public class StringToInetAddressCodec extends StringConvertingCodec<InetAddress>
     if (isNull(s)) {
       return null;
     }
+    if (s.isEmpty()) {
+      throw new InvalidTypeException("Cannot create inet address from empty string");
+    }
     try {
       return InetAddress.getByName(s);
     } catch (Exception e) {

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToUnknownTypeCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToUnknownTypeCodec.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.string;
+
+import com.datastax.driver.core.TypeCodec;
+import java.util.List;
+
+public class StringToUnknownTypeCodec<T> extends StringConvertingCodec<T> {
+
+  public StringToUnknownTypeCodec(TypeCodec<T> targetCodec, List<String> nullStrings) {
+    super(targetCodec, nullStrings);
+  }
+
+  @Override
+  public T externalToInternal(String s) {
+    if (isNull(s)) {
+      return null;
+    }
+    return getInternalCodec().parse(s);
+  }
+
+  @Override
+  public String internalToExternal(T o) {
+    if (o == null) {
+      return nullString();
+    }
+    String s = getInternalCodec().format(o);
+    // most codecs usually format null/empty values using the CQL keyword "NULL"
+    if (s == null || s.equalsIgnoreCase("NULL")) {
+      return nullString();
+    }
+    return s;
+  }
+}

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/dse/StringToDateRangeCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/dse/StringToDateRangeCodec.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.string.dse;
+
+import com.datastax.driver.dse.search.DateRange;
+import com.datastax.driver.dse.search.DateRangeCodec;
+import com.datastax.dsbulk.engine.internal.codecs.string.StringConvertingCodec;
+import com.datastax.dsbulk.engine.internal.codecs.util.CodecUtils;
+import java.util.List;
+
+public class StringToDateRangeCodec extends StringConvertingCodec<DateRange> {
+
+  public StringToDateRangeCodec(List<String> nullStrings) {
+    super(DateRangeCodec.INSTANCE, nullStrings);
+  }
+
+  @Override
+  public DateRange externalToInternal(String s) {
+    if (isNull(s)) {
+      return null;
+    }
+    return CodecUtils.parseDateRange(s);
+  }
+
+  @Override
+  public String internalToExternal(DateRange value) {
+    if (value == null) {
+      return nullString();
+    }
+    return value.toString();
+  }
+}

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/dse/StringToLineStringCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/dse/StringToLineStringCodec.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.string.dse;
+
+import com.datastax.driver.dse.geometry.LineString;
+import com.datastax.driver.dse.geometry.codecs.LineStringCodec;
+import com.datastax.dsbulk.engine.internal.codecs.string.StringConvertingCodec;
+import com.datastax.dsbulk.engine.internal.codecs.util.CodecUtils;
+import java.util.List;
+
+public class StringToLineStringCodec extends StringConvertingCodec<LineString> {
+
+  public StringToLineStringCodec(List<String> nullStrings) {
+    super(LineStringCodec.INSTANCE, nullStrings);
+  }
+
+  @Override
+  public LineString externalToInternal(String s) {
+    if (isNull(s)) {
+      return null;
+    }
+    return CodecUtils.parseLineString(s);
+  }
+
+  @Override
+  public String internalToExternal(LineString value) {
+    if (value == null) {
+      return nullString();
+    }
+    return value.asWellKnownText();
+  }
+}

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/dse/StringToPointCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/dse/StringToPointCodec.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.string.dse;
+
+import com.datastax.driver.dse.geometry.Point;
+import com.datastax.driver.dse.geometry.codecs.PointCodec;
+import com.datastax.dsbulk.engine.internal.codecs.string.StringConvertingCodec;
+import com.datastax.dsbulk.engine.internal.codecs.util.CodecUtils;
+import java.util.List;
+
+public class StringToPointCodec extends StringConvertingCodec<Point> {
+
+  public StringToPointCodec(List<String> nullStrings) {
+    super(PointCodec.INSTANCE, nullStrings);
+  }
+
+  @Override
+  public Point externalToInternal(String s) {
+    if (isNull(s)) {
+      return null;
+    }
+    return CodecUtils.parsePoint(s);
+  }
+
+  @Override
+  public String internalToExternal(Point value) {
+    if (value == null) {
+      return nullString();
+    }
+    return value.asWellKnownText();
+  }
+}

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/dse/StringToPolygonCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/dse/StringToPolygonCodec.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.string.dse;
+
+import com.datastax.driver.dse.geometry.Polygon;
+import com.datastax.driver.dse.geometry.codecs.PolygonCodec;
+import com.datastax.dsbulk.engine.internal.codecs.string.StringConvertingCodec;
+import com.datastax.dsbulk.engine.internal.codecs.util.CodecUtils;
+import java.util.List;
+
+public class StringToPolygonCodec extends StringConvertingCodec<Polygon> {
+
+  public StringToPolygonCodec(List<String> nullStrings) {
+    super(PolygonCodec.INSTANCE, nullStrings);
+  }
+
+  @Override
+  public Polygon externalToInternal(String s) {
+    if (isNull(s)) {
+      return null;
+    }
+    return CodecUtils.parsePolygon(s);
+  }
+
+  @Override
+  public String internalToExternal(Polygon value) {
+    if (value == null) {
+      return nullString();
+    }
+    return value.asWellKnownText();
+  }
+}

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBigDecimalCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBigDecimalCodecTest.java
@@ -71,8 +71,6 @@ class JsonNodeToBigDecimalCodecTest {
         .toInternal(null)
         .convertsFromExternal(JSON_NODE_FACTORY.textNode("NULL"))
         .toInternal(null)
-        .convertsFromExternal(JSON_NODE_FACTORY.textNode(""))
-        .toInternal(null)
         .convertsFromExternal(JSON_NODE_FACTORY.nullNode())
         .toInternal(null);
   }
@@ -90,6 +88,8 @@ class JsonNodeToBigDecimalCodecTest {
 
   @Test
   void should_not_convert_from_invalid_external() {
-    assertThat(codec).cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid decimal"));
+    assertThat(codec)
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode(""))
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid decimal"));
   }
 }

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBigIntegerCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBigIntegerCodecTest.java
@@ -71,8 +71,6 @@ class JsonNodeToBigIntegerCodecTest {
         .toInternal(null)
         .convertsFromExternal(JSON_NODE_FACTORY.textNode("NULL"))
         .toInternal(null)
-        .convertsFromExternal(JSON_NODE_FACTORY.textNode(""))
-        .toInternal(null)
         .convertsFromExternal(JSON_NODE_FACTORY.nullNode())
         .toInternal(null);
   }
@@ -91,6 +89,7 @@ class JsonNodeToBigIntegerCodecTest {
   @Test
   void should_not_convert_from_invalid_external() {
     assertThat(codec)
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode(""))
         .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid biginteger"));
   }
 }

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBlobCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBlobCodecTest.java
@@ -36,15 +36,13 @@ class JsonNodeToBlobCodecTest {
         .convertsFromExternal(JSON_NODE_FACTORY.binaryNode(data))
         .toInternal(dataBb)
         .convertsFromExternal(JSON_NODE_FACTORY.binaryNode(empty))
-        .toInternal(null)
+        .toInternal(emptyBb)
         .convertsFromExternal(JSON_NODE_FACTORY.textNode(data64))
         .toInternal(dataBb)
         .convertsFromExternal(JSON_NODE_FACTORY.textNode(dataHex))
         .toInternal(dataBb)
         .convertsFromExternal(JSON_NODE_FACTORY.textNode("0x"))
         .toInternal(emptyBb)
-        .convertsFromExternal(JSON_NODE_FACTORY.textNode(""))
-        .toInternal(null)
         .convertsFromExternal(JSON_NODE_FACTORY.nullNode())
         .toInternal(null)
         .convertsFromExternal(null)
@@ -66,6 +64,8 @@ class JsonNodeToBlobCodecTest {
 
   @Test
   void should_not_convert_from_invalid_external() {
-    assertThat(codec).cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid binary"));
+    assertThat(codec)
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode(""))
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid binary"));
   }
 }

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBooleanCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBooleanCodecTest.java
@@ -44,8 +44,6 @@ class JsonNodeToBooleanCodecTest {
         .convertsFromExternal(JSON_NODE_FACTORY.textNode("NULL"))
         .toInternal(null)
         .convertsFromExternal(JSON_NODE_FACTORY.nullNode())
-        .toInternal(null)
-        .convertsFromExternal(JSON_NODE_FACTORY.textNode(""))
         .toInternal(null);
   }
 
@@ -62,6 +60,8 @@ class JsonNodeToBooleanCodecTest {
 
   @Test
   void should_not_convert_from_invalid_external() {
-    assertThat(codec).cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid boolean"));
+    assertThat(codec)
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode(""))
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid boolean"));
   }
 }

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToByteCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToByteCodecTest.java
@@ -68,8 +68,6 @@ class JsonNodeToByteCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal(JSON_NODE_FACTORY.textNode("NULL"))
-        .toInternal(null)
-        .convertsFromExternal(JSON_NODE_FACTORY.textNode(""))
         .toInternal(null);
   }
 
@@ -89,6 +87,7 @@ class JsonNodeToByteCodecTest {
   @Test
   void should_not_convert_from_invalid_external() {
     assertThat(codec)
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode(""))
         .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid byte"))
         .cannotConvertFromExternal(JSON_NODE_FACTORY.numberNode(1.2))
         .cannotConvertFromExternal(JSON_NODE_FACTORY.numberNode(128))

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToDoubleCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToDoubleCodecTest.java
@@ -77,8 +77,6 @@ class JsonNodeToDoubleCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal(JSON_NODE_FACTORY.textNode("NULL"))
-        .toInternal(null)
-        .convertsFromExternal(JSON_NODE_FACTORY.textNode(""))
         .toInternal(null);
   }
 
@@ -97,6 +95,8 @@ class JsonNodeToDoubleCodecTest {
 
   @Test
   void should_not_convert_from_invalid_external() {
-    assertThat(codec).cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid double"));
+    assertThat(codec)
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode(""))
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid double"));
   }
 }

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToDurationCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToDurationCodecTest.java
@@ -33,8 +33,6 @@ class JsonNodeToDurationCodecTest {
         .convertsFromExternal(
             JSON_NODE_FACTORY.textNode("P0001-03-00T02:10:00")) // alternative ISO 8601 pattern
         .toInternal(duration)
-        .convertsFromExternal(JSON_NODE_FACTORY.textNode(""))
-        .toInternal(null)
         .convertsFromExternal(JSON_NODE_FACTORY.nullNode())
         .toInternal(null)
         .convertsFromExternal(null)
@@ -49,12 +47,13 @@ class JsonNodeToDurationCodecTest {
         .convertsFromInternal(duration)
         .toExternal(JSON_NODE_FACTORY.textNode("1y3mo2h10m"))
         .convertsFromInternal(null)
-        .toExternal(null);
+        .toExternal(JSON_NODE_FACTORY.nullNode());
   }
 
   @Test
   void should_not_convert_from_invalid_external() {
     assertThat(codec)
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode(""))
         .cannotConvertFromExternal(
             JSON_NODE_FACTORY.textNode("1Y3M4D")) // The minutes should be after days
         .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid duration"));

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToFloatCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToFloatCodecTest.java
@@ -88,8 +88,6 @@ class JsonNodeToFloatCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal(JSON_NODE_FACTORY.textNode("NULL"))
-        .toInternal(null)
-        .convertsFromExternal(JSON_NODE_FACTORY.textNode(""))
         .toInternal(null);
   }
 
@@ -112,6 +110,8 @@ class JsonNodeToFloatCodecTest {
 
   @Test
   void should_not_convert_from_invalid_external() {
-    assertThat(codec).cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid float"));
+    assertThat(codec)
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode(""))
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid float"));
   }
 }

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToInetAddressCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToInetAddressCodecTest.java
@@ -30,8 +30,6 @@ class JsonNodeToInetAddressCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal(JSON_NODE_FACTORY.textNode("NULL"))
-        .toInternal(null)
-        .convertsFromExternal(JSON_NODE_FACTORY.textNode(""))
         .toInternal(null);
   }
 
@@ -49,6 +47,7 @@ class JsonNodeToInetAddressCodecTest {
   @Test
   void should_not_convert_from_invalid_external() {
     assertThat(codec)
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode(""))
         .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid inet address"));
   }
 }

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToInstantCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToInstantCodecTest.java
@@ -66,8 +66,6 @@ class JsonNodeToInstantCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal(JSON_NODE_FACTORY.textNode("NULL"))
-        .toInternal(null)
-        .convertsFromExternal(JSON_NODE_FACTORY.textNode(""))
         .toInternal(null);
     codec =
         new JsonNodeToInstantCodec(
@@ -78,8 +76,6 @@ class JsonNodeToInstantCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal(JSON_NODE_FACTORY.textNode("NULL"))
-        .toInternal(null)
-        .convertsFromExternal(JSON_NODE_FACTORY.textNode(""))
         .toInternal(null);
     codec =
         new JsonNodeToInstantCodec(
@@ -134,6 +130,7 @@ class JsonNodeToInstantCodecTest {
         new JsonNodeToInstantCodec(
             temporalFormat1, numberFormat, MILLISECONDS, EPOCH.atZone(UTC), newArrayList("NULL"));
     assertThat(codec)
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode(""))
         .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid date format"));
   }
 }

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToIntegerCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToIntegerCodecTest.java
@@ -73,8 +73,6 @@ class JsonNodeToIntegerCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal(JSON_NODE_FACTORY.textNode("NULL"))
-        .toInternal(null)
-        .convertsFromExternal(JSON_NODE_FACTORY.textNode(""))
         .toInternal(null);
   }
 
@@ -94,6 +92,7 @@ class JsonNodeToIntegerCodecTest {
   @Test
   void should_not_convert_from_invalid_external() {
     assertThat(codec)
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode(""))
         .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid integer"))
         .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("1.2"))
         .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("2147483648"))

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToListCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToListCodecTest.java
@@ -56,7 +56,7 @@ class JsonNodeToListCodecTest {
           nullStrings);
 
   private final JsonNodeToStringCodec eltCodec2 =
-      new JsonNodeToStringCodec(TypeCodec.varchar(), nullStrings);
+      new JsonNodeToStringCodec(TypeCodec.varchar(), objectMapper, nullStrings);
 
   private final TypeCodec<List<Double>> listCodec1 = list(cdouble());
   private final TypeCodec<List<String>> listCodec2 = list(varchar());

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToLocalDateCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToLocalDateCodecTest.java
@@ -40,8 +40,6 @@ class JsonNodeToLocalDateCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal(JSON_NODE_FACTORY.textNode("NULL"))
-        .toInternal(null)
-        .convertsFromExternal(JSON_NODE_FACTORY.textNode(""))
         .toInternal(null);
     codec = new JsonNodeToLocalDateCodec(format2, nullStrings);
     assertThat(codec)
@@ -50,8 +48,6 @@ class JsonNodeToLocalDateCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal(JSON_NODE_FACTORY.textNode("NULL"))
-        .toInternal(null)
-        .convertsFromExternal(JSON_NODE_FACTORY.textNode(""))
         .toInternal(null);
   }
 
@@ -75,6 +71,7 @@ class JsonNodeToLocalDateCodecTest {
   void should_not_convert_from_invalid_external() {
     JsonNodeToLocalDateCodec codec = new JsonNodeToLocalDateCodec(format1, nullStrings);
     assertThat(codec)
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode(""))
         .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid date format"));
   }
 }

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToLocalTimeCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToLocalTimeCodecTest.java
@@ -43,8 +43,6 @@ class JsonNodeToLocalTimeCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal(JSON_NODE_FACTORY.textNode("NULL"))
-        .toInternal(null)
-        .convertsFromExternal(JSON_NODE_FACTORY.textNode(""))
         .toInternal(null);
     codec = new JsonNodeToLocalTimeCodec(format2, nullStrings);
     assertThat(codec)
@@ -53,8 +51,6 @@ class JsonNodeToLocalTimeCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal(JSON_NODE_FACTORY.textNode("NULL"))
-        .toInternal(null)
-        .convertsFromExternal(JSON_NODE_FACTORY.textNode(""))
         .toInternal(null);
   }
 
@@ -78,6 +74,7 @@ class JsonNodeToLocalTimeCodecTest {
   void should_not_convert_from_invalid_external() {
     JsonNodeToLocalTimeCodec codec = new JsonNodeToLocalTimeCodec(ISO_LOCAL_DATE, nullStrings);
     assertThat(codec)
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode(""))
         .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid date format"));
   }
 }

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToLongCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToLongCodecTest.java
@@ -75,8 +75,6 @@ class JsonNodeToLongCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal(JSON_NODE_FACTORY.textNode("NULL"))
-        .toInternal(null)
-        .convertsFromExternal(JSON_NODE_FACTORY.textNode(""))
         .toInternal(null);
   }
 
@@ -96,6 +94,7 @@ class JsonNodeToLongCodecTest {
   @Test
   void should_not_convert_from_invalid_external() {
     assertThat(codec)
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode(""))
         .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid long"))
         .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("1.2"))
         .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("9223372036854775808"))

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToMapCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToMapCodecTest.java
@@ -43,7 +43,7 @@ class JsonNodeToMapCodecTest {
   private final FastThreadLocal<NumberFormat> numberFormat =
       CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
-  private final List<String> nullStrings = newArrayList("NULL");
+  private final List<String> nullStrings = newArrayList("NULL", "");
 
   private final ConvertingCodec<String, Double> keyCodec =
       new StringToDoubleCodec(
@@ -62,7 +62,7 @@ class JsonNodeToMapCodecTest {
   private final JsonNodeToListCodec<String> valueCodec =
       new JsonNodeToListCodec<>(
           stringListCodec,
-          new JsonNodeToStringCodec(TypeCodec.varchar(), nullStrings),
+          new JsonNodeToStringCodec(TypeCodec.varchar(), objectMapper, nullStrings),
           objectMapper,
           nullStrings);
 

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToSetCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToSetCodecTest.java
@@ -58,7 +58,7 @@ class JsonNodeToSetCodecTest {
           nullStrings);
 
   private final JsonNodeToStringCodec eltCodec2 =
-      new JsonNodeToStringCodec(TypeCodec.varchar(), nullStrings);
+      new JsonNodeToStringCodec(TypeCodec.varchar(), objectMapper, nullStrings);
 
   private final TypeCodec<Set<Double>> setCodec1 = set(cdouble());
   private final TypeCodec<Set<String>> setCodec2 = set(varchar());

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToShortCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToShortCodecTest.java
@@ -73,8 +73,6 @@ class JsonNodeToShortCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal(JSON_NODE_FACTORY.textNode("NULL"))
-        .toInternal(null)
-        .convertsFromExternal(JSON_NODE_FACTORY.textNode(""))
         .toInternal(null);
   }
 
@@ -94,6 +92,7 @@ class JsonNodeToShortCodecTest {
   @Test
   void should_not_convert_from_invalid_external() {
     assertThat(codec)
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode(""))
         .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid short"))
         .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("1.2"))
         .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("32768"))

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToStringCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToStringCodecTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.json;
+
+import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
+import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
+import static com.google.common.collect.Lists.newArrayList;
+
+import com.datastax.driver.core.TypeCodec;
+import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class JsonNodeToStringCodecTest {
+
+  private List<String> nullStrings = newArrayList("NULL");
+  private ObjectMapper objectMapper = CodecSettings.getObjectMapper();
+
+  @Test
+  void should_convert_from_valid_external() throws IOException {
+    JsonNodeToStringCodec codec =
+        new JsonNodeToStringCodec(TypeCodec.varchar(), objectMapper, nullStrings);
+    assertThat(codec)
+        .convertsFromExternal(JSON_NODE_FACTORY.textNode("foo"))
+        .toInternal("foo")
+        .convertsFromExternal(JSON_NODE_FACTORY.textNode("\"foo\""))
+        .toInternal("\"foo\"")
+        .convertsFromExternal(JSON_NODE_FACTORY.textNode("'foo'"))
+        .toInternal("'foo'")
+        .convertsFromExternal(JSON_NODE_FACTORY.numberNode(42))
+        .toInternal("42")
+        .convertsFromExternal(objectMapper.readTree("{\"foo\":42}"))
+        .toInternal("{\"foo\":42}")
+        .convertsFromExternal(objectMapper.readTree("[1,2,3]"))
+        .toInternal("[1,2,3]")
+        .convertsFromExternal(null)
+        .toInternal(null)
+        .convertsFromExternal(JSON_NODE_FACTORY.textNode("NULL"))
+        .toInternal(null)
+        .convertsFromExternal(JSON_NODE_FACTORY.textNode(""))
+        .toInternal("")
+        .convertsFromExternal(JSON_NODE_FACTORY.nullNode())
+        .toInternal(null);
+  }
+
+  @Test
+  void should_convert_from_valid_internal() throws IOException {
+    JsonNodeToStringCodec codec =
+        new JsonNodeToStringCodec(TypeCodec.varchar(), objectMapper, nullStrings);
+    assertThat(codec)
+        .convertsFromInternal("foo")
+        .toExternal(JSON_NODE_FACTORY.textNode("foo"))
+        .convertsFromInternal("\"foo\"")
+        .toExternal(JSON_NODE_FACTORY.textNode("\"foo\""))
+        .convertsFromInternal("'foo'")
+        .toExternal(JSON_NODE_FACTORY.textNode("'foo'"))
+        .convertsFromInternal("42")
+        .toExternal(JSON_NODE_FACTORY.numberNode(42))
+        .convertsFromInternal("{\"foo\":42}")
+        .toExternal(objectMapper.readTree("{\"foo\":42}"))
+        .convertsFromInternal("[1,2,3]")
+        .toExternal(objectMapper.readTree("[1,2,3]"))
+        .convertsFromInternal(null)
+        .toExternal(JSON_NODE_FACTORY.nullNode())
+        .convertsFromInternal("")
+        .toExternal(JSON_NODE_FACTORY.textNode(""));
+  }
+}

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToTupleCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToTupleCodecTest.java
@@ -48,14 +48,14 @@ class JsonNodeToTupleCodecTest {
 
   private final TupleType tupleType = newTupleType(V4, codecRegistry, timestamp(), varchar());
 
-  private final List<String> nullStrings = newArrayList("NULL");
+  private final List<String> nullStrings = newArrayList("NULL", "");
 
   private final ConvertingCodec eltCodec1 =
       new JsonNodeToInstantCodec(
           CQL_DATE_TIME_FORMAT, numberFormat, MILLISECONDS, EPOCH.atZone(UTC), nullStrings);
 
   private final ConvertingCodec eltCodec2 =
-      new JsonNodeToStringCodec(TypeCodec.varchar(), nullStrings);
+      new JsonNodeToStringCodec(TypeCodec.varchar(), objectMapper, nullStrings);
 
   @SuppressWarnings("unchecked")
   private final List<ConvertingCodec<JsonNode, Object>> eltCodecs =
@@ -76,7 +76,7 @@ class JsonNodeToTupleCodecTest {
         .convertsFromExternal(objectMapper.readTree("[\"2016-07-24T20:34:12.999Z\",\"+01:00\"]"))
         .toInternal(tupleType.newValue(Instant.parse("2016-07-24T20:34:12.999Z"), "+01:00"))
         .convertsFromExternal(objectMapper.readTree("[\"\",\"\"]"))
-        .toInternal(tupleType.newValue(null, ""))
+        .toInternal(tupleType.newValue(null, null))
         .convertsFromExternal(objectMapper.readTree("[\"NULL\",\"NULL\"]"))
         .toInternal(tupleType.newValue(null, null))
         .convertsFromExternal(objectMapper.readTree("[null,null]"))

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToUDTCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToUDTCodecTest.java
@@ -59,7 +59,7 @@ class JsonNodeToUDTCodecTest {
   private final FastThreadLocal<NumberFormat> numberFormat =
       CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
-  private final List<String> nullStrings = newArrayList("NULL");
+  private final List<String> nullStrings = newArrayList("NULL", "");
 
   // UDT 1
 

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToUUIDCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToUUIDCodecTest.java
@@ -56,8 +56,6 @@ class JsonNodeToUUIDCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal(JSON_NODE_FACTORY.textNode("NULL"))
-        .toInternal(null)
-        .convertsFromExternal(JSON_NODE_FACTORY.textNode(""))
         .toInternal(null);
 
     assertThat(new JsonNodeToUUIDCodec(TypeCodec.uuid(), instantCodec, MIN, nullStrings))
@@ -137,6 +135,8 @@ class JsonNodeToUUIDCodecTest {
 
   @Test
   void should_not_convert_from_invalid_external() {
-    assertThat(codec).cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid UUID"));
+    assertThat(codec)
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode(""))
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid UUID"));
   }
 }

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToUnknownTypeCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToUnknownTypeCodecTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.json;
+
+import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
+import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
+import static com.google.common.collect.Lists.newArrayList;
+
+import com.datastax.dsbulk.engine.internal.codecs.string.StringToUnknownTypeCodecTest.Fruit;
+import com.datastax.dsbulk.engine.internal.codecs.string.StringToUnknownTypeCodecTest.FruitCodec;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class JsonNodeToUnknownTypeCodecTest {
+
+  private FruitCodec targetCodec = new FruitCodec();
+  private List<String> nullStrings = newArrayList("NULL");
+  private Fruit banana = new Fruit("banana");
+
+  @Test
+  void should_convert_from_valid_external() {
+    JsonNodeToUnknownTypeCodec<Fruit> codec =
+        new JsonNodeToUnknownTypeCodec<>(targetCodec, nullStrings);
+    assertThat(codec)
+        .convertsFromExternal(JSON_NODE_FACTORY.textNode("banana"))
+        .toInternal(banana)
+        .convertsFromExternal(null)
+        .toInternal(null)
+        .convertsFromExternal(JSON_NODE_FACTORY.textNode("NULL"))
+        .toInternal(null)
+        .convertsFromExternal(JSON_NODE_FACTORY.nullNode())
+        .toInternal(null);
+  }
+
+  @Test
+  void should_convert_from_valid_internal() {
+    JsonNodeToUnknownTypeCodec<Fruit> codec =
+        new JsonNodeToUnknownTypeCodec<>(targetCodec, nullStrings);
+    assertThat(codec).convertsFromInternal(banana).toExternal(JSON_NODE_FACTORY.textNode("banana"));
+  }
+
+  @Test
+  void should_not_convert_from_invalid_external() {
+    JsonNodeToUnknownTypeCodec<Fruit> codec =
+        new JsonNodeToUnknownTypeCodec<>(targetCodec, nullStrings);
+    assertThat(codec)
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode(""))
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid fruit literal"));
+  }
+}

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/dse/JsonNodeToDateRangeCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/dse/JsonNodeToDateRangeCodecTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.json.dse;
+
+import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
+import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
+import static com.google.common.collect.Lists.newArrayList;
+
+import com.datastax.driver.dse.search.DateRange;
+import java.text.ParseException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class JsonNodeToDateRangeCodecTest {
+
+  private List<String> nullStrings = newArrayList("NULL");
+  private DateRange dateRange = DateRange.parse("[* TO 2014-12-01]");
+
+  JsonNodeToDateRangeCodecTest() throws ParseException {}
+
+  @Test
+  void should_convert_from_valid_external() {
+
+    JsonNodeToDateRangeCodec codec = new JsonNodeToDateRangeCodec(nullStrings);
+    assertThat(codec)
+        .convertsFromExternal(JSON_NODE_FACTORY.textNode("[* TO 2014-12-01]"))
+        .toInternal(dateRange)
+        .convertsFromExternal(null)
+        .toInternal(null)
+        .convertsFromExternal(JSON_NODE_FACTORY.textNode("NULL"))
+        .toInternal(null)
+        .convertsFromExternal(JSON_NODE_FACTORY.nullNode())
+        .toInternal(null);
+  }
+
+  @Test
+  void should_convert_from_valid_internal() {
+    JsonNodeToDateRangeCodec codec = new JsonNodeToDateRangeCodec(nullStrings);
+    assertThat(codec)
+        .convertsFromInternal(dateRange)
+        .toExternal(JSON_NODE_FACTORY.textNode("[* TO 2014-12-01]"));
+  }
+
+  @Test
+  void should_not_convert_from_invalid_external() {
+    JsonNodeToDateRangeCodec codec = new JsonNodeToDateRangeCodec(nullStrings);
+    assertThat(codec)
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode(""))
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid date range literal"));
+  }
+}

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/dse/JsonNodeToLineStringCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/dse/JsonNodeToLineStringCodecTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.json.dse;
+
+import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
+import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
+import static com.google.common.collect.Lists.newArrayList;
+
+import com.datastax.driver.dse.geometry.LineString;
+import com.datastax.driver.dse.geometry.Point;
+import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class JsonNodeToLineStringCodecTest {
+
+  private List<String> nullStrings = newArrayList("NULL");
+  private LineString lineString =
+      new LineString(new Point(30, 10), new Point(10, 30), new Point(40, 40));
+  private ObjectMapper objectMapper = CodecSettings.getObjectMapper();
+  private JsonNode geoJsonNode =
+      objectMapper.readTree(
+          "{\"type\":\"LineString\",\"coordinates\":[[30.0,10.0],[10.0,30.0],[40.0,40.0]]}");
+
+  JsonNodeToLineStringCodecTest() throws IOException {}
+
+  @Test
+  void should_convert_from_valid_external() throws IOException {
+    JsonNodeToLineStringCodec codec = new JsonNodeToLineStringCodec(objectMapper, nullStrings);
+    assertThat(codec)
+        .convertsFromExternal(JSON_NODE_FACTORY.textNode("'LINESTRING (30 10, 10 30, 40 40)'"))
+        .toInternal(lineString)
+        .convertsFromExternal(JSON_NODE_FACTORY.textNode(" linestring (30 10, 10 30, 40 40) "))
+        .toInternal(lineString)
+        .convertsFromExternal(
+            JSON_NODE_FACTORY.textNode(objectMapper.writeValueAsString(geoJsonNode)))
+        .toInternal(lineString)
+        .convertsFromExternal(geoJsonNode)
+        .toInternal(lineString)
+        .convertsFromExternal(null)
+        .toInternal(null)
+        .convertsFromExternal(JSON_NODE_FACTORY.textNode("NULL"))
+        .toInternal(null)
+        .convertsFromExternal(JSON_NODE_FACTORY.nullNode())
+        .toInternal(null);
+  }
+
+  @Test
+  void should_convert_from_valid_internal() {
+    JsonNodeToLineStringCodec codec = new JsonNodeToLineStringCodec(objectMapper, nullStrings);
+    assertThat(codec).convertsFromInternal(lineString).toExternal(geoJsonNode);
+  }
+
+  @Test
+  void should_not_convert_from_invalid_external() {
+    JsonNodeToLineStringCodec codec = new JsonNodeToLineStringCodec(objectMapper, nullStrings);
+    assertThat(codec)
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode(""))
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid linestring literal"));
+  }
+}

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/dse/JsonNodeToPointCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/dse/JsonNodeToPointCodecTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.json.dse;
+
+import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
+import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
+import static com.google.common.collect.Lists.newArrayList;
+
+import com.datastax.driver.dse.geometry.Point;
+import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class JsonNodeToPointCodecTest {
+
+  private List<String> nullStrings = newArrayList("NULL");
+  private Point point = new Point(-1.1, -2.2);
+  private ObjectMapper objectMapper = CodecSettings.getObjectMapper();
+  private JsonNode geoJsonNode =
+      objectMapper.readTree("{\"type\":\"Point\",\"coordinates\":[-1.1,-2.2]}");
+
+  JsonNodeToPointCodecTest() throws IOException {}
+
+  @Test
+  void should_convert_from_valid_external() throws IOException {
+    JsonNodeToPointCodec codec = new JsonNodeToPointCodec(objectMapper, nullStrings);
+    assertThat(codec)
+        .convertsFromExternal(JSON_NODE_FACTORY.textNode("'POINT (-1.1 -2.2)'"))
+        .toInternal(point)
+        .convertsFromExternal(JSON_NODE_FACTORY.textNode(" point (-1.1 -2.2) "))
+        .toInternal(point)
+        .convertsFromExternal(
+            JSON_NODE_FACTORY.textNode(objectMapper.writeValueAsString(geoJsonNode)))
+        .toInternal(point)
+        .convertsFromExternal(geoJsonNode)
+        .toInternal(point)
+        .convertsFromExternal(null)
+        .toInternal(null)
+        .convertsFromExternal(JSON_NODE_FACTORY.textNode("NULL"))
+        .toInternal(null);
+  }
+
+  @Test
+  void should_convert_from_valid_internal() {
+    JsonNodeToPointCodec codec = new JsonNodeToPointCodec(objectMapper, nullStrings);
+    assertThat(codec).convertsFromInternal(point).toExternal(geoJsonNode);
+  }
+
+  @Test
+  void should_not_convert_from_invalid_external() {
+    JsonNodeToPointCodec codec = new JsonNodeToPointCodec(objectMapper, nullStrings);
+    assertThat(codec)
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode(""))
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid point literal"));
+  }
+}

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/dse/JsonNodeToPolygonCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/dse/JsonNodeToPolygonCodecTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.json.dse;
+
+import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
+import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
+import static com.google.common.collect.Lists.newArrayList;
+
+import com.datastax.driver.dse.geometry.Point;
+import com.datastax.driver.dse.geometry.Polygon;
+import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class JsonNodeToPolygonCodecTest {
+
+  private List<String> nullStrings = newArrayList("NULL");
+  private Polygon polygon =
+      new Polygon(new Point(30, 10), new Point(10, 20), new Point(20, 40), new Point(40, 40));
+  private ObjectMapper objectMapper = CodecSettings.getObjectMapper();
+  private JsonNode geoJsonNode =
+      objectMapper.readTree(
+          "{\"type\":\"Polygon\",\"coordinates\":[[[30.0,10.0],[10.0,20.0],[20.0,40.0],[40.0,40.0],[30.0,10.0]]]}");
+
+  JsonNodeToPolygonCodecTest() throws IOException {}
+
+  @Test
+  void should_convert_from_valid_external() throws IOException {
+    JsonNodeToPolygonCodec codec = new JsonNodeToPolygonCodec(objectMapper, nullStrings);
+    assertThat(codec)
+        .convertsFromExternal(
+            JSON_NODE_FACTORY.textNode("'POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))'"))
+        .toInternal(polygon)
+        .convertsFromExternal(
+            JSON_NODE_FACTORY.textNode(" polygon ((30 10, 40 40, 20 40, 10 20, 30 10)) "))
+        .toInternal(polygon)
+        .convertsFromExternal(
+            JSON_NODE_FACTORY.textNode(objectMapper.writeValueAsString(geoJsonNode)))
+        .toInternal(polygon)
+        .convertsFromExternal(geoJsonNode)
+        .toInternal(polygon)
+        .convertsFromExternal(null)
+        .toInternal(null)
+        .convertsFromExternal(JSON_NODE_FACTORY.textNode("NULL"))
+        .toInternal(null)
+        .convertsFromExternal(JSON_NODE_FACTORY.nullNode())
+        .toInternal(null);
+  }
+
+  @Test
+  void should_convert_from_valid_internal() {
+    JsonNodeToPolygonCodec codec = new JsonNodeToPolygonCodec(objectMapper, nullStrings);
+    assertThat(codec).convertsFromInternal(polygon).toExternal(geoJsonNode);
+  }
+
+  @Test
+  void should_not_convert_from_invalid_external() {
+    JsonNodeToPolygonCodec codec = new JsonNodeToPolygonCodec(objectMapper, nullStrings);
+    assertThat(codec)
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode(""))
+        .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid polygon literal"));
+  }
+}

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBigDecimalCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBigDecimalCodecTest.java
@@ -67,8 +67,6 @@ class StringToBigDecimalCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal("NULL")
-        .toInternal(null)
-        .convertsFromExternal("")
         .toInternal(null);
   }
 
@@ -85,6 +83,8 @@ class StringToBigDecimalCodecTest {
 
   @Test
   void should_not_convert_from_invalid_external() {
-    assertThat(codec).cannotConvertFromExternal("not a valid decimal");
+    assertThat(codec)
+        .cannotConvertFromExternal("")
+        .cannotConvertFromExternal("not a valid decimal");
   }
 }

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBigIntegerCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBigIntegerCodecTest.java
@@ -66,8 +66,6 @@ class StringToBigIntegerCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal("NULL")
-        .toInternal(null)
-        .convertsFromExternal("")
         .toInternal(null);
   }
 
@@ -85,6 +83,7 @@ class StringToBigIntegerCodecTest {
   @Test
   void should_not_convert_from_invalid_external() {
     assertThat(codec)
+        .cannotConvertFromExternal("")
         .cannotConvertFromExternal("-1.234")
         .cannotConvertFromExternal("not a valid biginteger");
   }

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBlobCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBlobCodecTest.java
@@ -38,8 +38,6 @@ class StringToBlobCodecTest {
         .toInternal(dataBb)
         .convertsFromExternal("0x")
         .toInternal(emptyBb)
-        .convertsFromExternal("")
-        .toInternal(null)
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal("NULL")
@@ -59,6 +57,6 @@ class StringToBlobCodecTest {
 
   @Test
   void should_not_convert_from_invalid_external() {
-    assertThat(codec).cannotConvertFromExternal("not a valid binary");
+    assertThat(codec).cannotConvertFromExternal("").cannotConvertFromExternal("not a valid binary");
   }
 }

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBooleanCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBooleanCodecTest.java
@@ -40,8 +40,6 @@ class StringToBooleanCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal("NULL")
-        .toInternal(null)
-        .convertsFromExternal("")
         .toInternal(null);
   }
 
@@ -58,6 +56,8 @@ class StringToBooleanCodecTest {
 
   @Test
   void should_not_convert_from_invalid_external() {
-    assertThat(codec).cannotConvertFromExternal("not a valid boolean");
+    assertThat(codec)
+        .cannotConvertFromExternal("")
+        .cannotConvertFromExternal("not a valid boolean");
   }
 }

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToByteCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToByteCodecTest.java
@@ -68,8 +68,6 @@ class StringToByteCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal("NULL")
-        .toInternal(null)
-        .convertsFromExternal("")
         .toInternal(null);
   }
 
@@ -89,6 +87,7 @@ class StringToByteCodecTest {
   @Test
   void should_not_convert_from_invalid_external() {
     assertThat(codec)
+        .cannotConvertFromExternal("")
         .cannotConvertFromExternal("not a valid byte")
         .cannotConvertFromExternal("1.2")
         .cannotConvertFromExternal("128")

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToDoubleCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToDoubleCodecTest.java
@@ -68,8 +68,6 @@ class StringToDoubleCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal("NULL")
-        .toInternal(null)
-        .convertsFromExternal("")
         .toInternal(null);
   }
 
@@ -88,6 +86,6 @@ class StringToDoubleCodecTest {
 
   @Test
   void should_not_convert_from_invalid_external() {
-    assertThat(codec).cannotConvertFromExternal("not a valid double");
+    assertThat(codec).cannotConvertFromExternal("").cannotConvertFromExternal("not a valid double");
   }
 }

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToDurationCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToDurationCodecTest.java
@@ -31,8 +31,6 @@ class StringToDurationCodecTest {
         .toInternal(duration)
         .convertsFromExternal("P0001-03-00T02:10:00") // alternative ISO 8601 pattern
         .toInternal(duration)
-        .convertsFromExternal("")
-        .toInternal(null)
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal("NULL")
@@ -51,6 +49,7 @@ class StringToDurationCodecTest {
   @Test
   void should_not_convert_from_invalid_external() {
     assertThat(codec)
+        .cannotConvertFromExternal("")
         .cannotConvertFromExternal("1Y3M4D") // The minutes should be after days
         .cannotConvertFromExternal("not a valid duration");
   }

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToFloatCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToFloatCodecTest.java
@@ -71,8 +71,6 @@ class StringToFloatCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal("NULL")
-        .toInternal(null)
-        .convertsFromExternal("")
         .toInternal(null);
   }
 
@@ -93,6 +91,6 @@ class StringToFloatCodecTest {
 
   @Test
   void should_not_convert_from_invalid_external() {
-    assertThat(codec).cannotConvertFromExternal("not a valid float");
+    assertThat(codec).cannotConvertFromExternal("").cannotConvertFromExternal("not a valid float");
   }
 }

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToInetAddressCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToInetAddressCodecTest.java
@@ -28,8 +28,6 @@ class StringToInetAddressCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal("NULL")
-        .toInternal(null)
-        .convertsFromExternal("")
         .toInternal(null);
   }
 
@@ -46,6 +44,8 @@ class StringToInetAddressCodecTest {
 
   @Test
   void should_not_convert_from_invalid_external() {
-    assertThat(codec).cannotConvertFromExternal("not a valid inet address");
+    assertThat(codec)
+        .cannotConvertFromExternal("")
+        .cannotConvertFromExternal("not a valid inet address");
   }
 }

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToInstantCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToInstantCodecTest.java
@@ -62,8 +62,6 @@ class StringToInstantCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal("NULL")
-        .toInternal(null)
-        .convertsFromExternal("")
         .toInternal(null);
     codec =
         new StringToInstantCodec(
@@ -118,6 +116,8 @@ class StringToInstantCodecTest {
     StringToInstantCodec codec =
         new StringToInstantCodec(
             temporalFormat1, numberFormat, MILLISECONDS, EPOCH.atZone(UTC), nullStrings);
-    assertThat(codec).cannotConvertFromExternal("not a valid date format");
+    assertThat(codec)
+        .cannotConvertFromExternal("")
+        .cannotConvertFromExternal("not a valid date format");
   }
 }

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToIntegerCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToIntegerCodecTest.java
@@ -70,8 +70,6 @@ class StringToIntegerCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal("NULL")
-        .toInternal(null)
-        .convertsFromExternal("")
         .toInternal(null);
   }
 
@@ -91,6 +89,7 @@ class StringToIntegerCodecTest {
   @Test
   void should_not_convert_from_invalid_external() {
     assertThat(codec)
+        .cannotConvertFromExternal("")
         .cannotConvertFromExternal("not a valid integer")
         .cannotConvertFromExternal("1.2")
         .cannotConvertFromExternal("2147483648")

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToListCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToListCodecTest.java
@@ -58,7 +58,7 @@ class StringToListCodecTest {
           nullStrings);
 
   private final JsonNodeToStringCodec eltCodec2 =
-      new JsonNodeToStringCodec(TypeCodec.varchar(), nullStrings);
+      new JsonNodeToStringCodec(TypeCodec.varchar(), objectMapper, nullStrings);
 
   private final TypeCodec<List<Double>> listCodec1 = list(cdouble());
   private final TypeCodec<List<String>> listCodec2 = list(varchar());

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToLocalDateCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToLocalDateCodecTest.java
@@ -39,8 +39,6 @@ class StringToLocalDateCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal("NULL")
-        .toInternal(null)
-        .convertsFromExternal("")
         .toInternal(null);
     codec = new StringToLocalDateCodec(format2, nullStrings);
     assertThat(codec).convertsFromExternal("20160724").toInternal(LocalDate.parse("2016-07-24"));
@@ -57,6 +55,8 @@ class StringToLocalDateCodecTest {
   @Test
   void should_not_convert_from_invalid_external() {
     StringToLocalDateCodec codec = new StringToLocalDateCodec(format1, nullStrings);
-    assertThat(codec).cannotConvertFromExternal("not a valid date format");
+    assertThat(codec)
+        .cannotConvertFromExternal("")
+        .cannotConvertFromExternal("not a valid date format");
   }
 }

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToLocalTimeCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToLocalTimeCodecTest.java
@@ -41,8 +41,6 @@ class StringToLocalTimeCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal("NULL")
-        .toInternal(null)
-        .convertsFromExternal("")
         .toInternal(null);
     codec = new StringToLocalTimeCodec(format2, nullStrings);
     assertThat(codec)
@@ -65,6 +63,8 @@ class StringToLocalTimeCodecTest {
   @Test
   void should_not_convert_from_invalid_external() {
     StringToLocalTimeCodec codec = new StringToLocalTimeCodec(format1, nullStrings);
-    assertThat(codec).cannotConvertFromExternal("not a valid date format");
+    assertThat(codec)
+        .cannotConvertFromExternal("")
+        .cannotConvertFromExternal("not a valid date format");
   }
 }

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToLongCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToLongCodecTest.java
@@ -71,8 +71,6 @@ class StringToLongCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal("NULL")
-        .toInternal(null)
-        .convertsFromExternal("")
         .toInternal(null);
   }
 
@@ -92,6 +90,7 @@ class StringToLongCodecTest {
   @Test
   void should_not_convert_from_invalid_external() {
     assertThat(codec)
+        .cannotConvertFromExternal("")
         .cannotConvertFromExternal("not a valid long")
         .cannotConvertFromExternal("1.2")
         .cannotConvertFromExternal("9223372036854775808")

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToMapCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToMapCodecTest.java
@@ -45,7 +45,7 @@ class StringToMapCodecTest {
   private final FastThreadLocal<NumberFormat> numberFormat =
       CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
-  private final List<String> nullStrings = newArrayList("NULL");
+  private final List<String> nullStrings = newArrayList("NULL", "");
 
   private final StringToDoubleCodec keyCodec =
       new StringToDoubleCodec(
@@ -64,7 +64,7 @@ class StringToMapCodecTest {
   private final ConvertingCodec<JsonNode, List<String>> valueCodec =
       new JsonNodeToListCodec<>(
           stringListCodec,
-          new JsonNodeToStringCodec(TypeCodec.varchar(), nullStrings),
+          new JsonNodeToStringCodec(TypeCodec.varchar(), objectMapper, nullStrings),
           objectMapper,
           nullStrings);
 

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToSetCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToSetCodecTest.java
@@ -60,7 +60,7 @@ class StringToSetCodecTest {
           nullStrings);
 
   private final JsonNodeToStringCodec eltCodec2 =
-      new JsonNodeToStringCodec(TypeCodec.varchar(), nullStrings);
+      new JsonNodeToStringCodec(TypeCodec.varchar(), objectMapper, nullStrings);
 
   private final TypeCodec<Set<Double>> setCodec1 = set(cdouble());
   private final TypeCodec<Set<String>> setCodec2 = set(varchar());

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToShortCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToShortCodecTest.java
@@ -66,8 +66,6 @@ class StringToShortCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal("NULL")
-        .toInternal(null)
-        .convertsFromExternal("")
         .toInternal(null);
   }
 
@@ -87,6 +85,7 @@ class StringToShortCodecTest {
   @Test
   void should_not_convert_from_invalid_external() {
     assertThat(codec)
+        .cannotConvertFromExternal("")
         .cannotConvertFromExternal("not a valid short")
         .cannotConvertFromExternal("1.2")
         .cannotConvertFromExternal("32768")

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToStringCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToStringCodecTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.string;
+
+import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
+import static com.google.common.collect.Lists.newArrayList;
+
+import com.datastax.driver.core.TypeCodec;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class StringToStringCodecTest {
+
+  private List<String> nullStrings = newArrayList("NULL");
+
+  @Test
+  void should_convert_from_valid_external() {
+    StringToStringCodec codec = new StringToStringCodec(TypeCodec.varchar(), nullStrings);
+    assertThat(codec)
+        .convertsFromExternal("foo")
+        .toInternal("foo")
+        .convertsFromExternal(null)
+        .toInternal(null)
+        .convertsFromExternal("NULL")
+        .toInternal(null)
+        .convertsFromExternal("")
+        .toInternal("");
+  }
+
+  @Test
+  void should_convert_from_valid_internal() {
+    StringToStringCodec codec = new StringToStringCodec(TypeCodec.varchar(), nullStrings);
+    assertThat(codec)
+        .convertsFromInternal("foo")
+        .toExternal("foo")
+        .convertsFromInternal(null)
+        .toExternal("NULL")
+        .convertsFromInternal("")
+        .toExternal("");
+  }
+}

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToTupleCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToTupleCodecTest.java
@@ -50,14 +50,14 @@ class StringToTupleCodecTest {
 
   private final TupleType tupleType = newTupleType(V4, codecRegistry, timestamp(), varchar());
 
-  private final List<String> nullStrings = newArrayList("NULL");
+  private final List<String> nullStrings = newArrayList("NULL", "");
 
   private final ConvertingCodec eltCodec1 =
       new JsonNodeToInstantCodec(
           CQL_DATE_TIME_FORMAT, numberFormat, MILLISECONDS, EPOCH.atZone(UTC), nullStrings);
 
   private final ConvertingCodec eltCodec2 =
-      new JsonNodeToStringCodec(TypeCodec.varchar(), nullStrings);
+      new JsonNodeToStringCodec(TypeCodec.varchar(), objectMapper, nullStrings);
 
   @SuppressWarnings("unchecked")
   private final List<ConvertingCodec<JsonNode, Object>> eltCodecs =
@@ -82,7 +82,7 @@ class StringToTupleCodecTest {
         .convertsFromExternal("[\"2016-07-24T20:34:12.999Z\",\"+01:00\"]")
         .toInternal(tupleType.newValue(Instant.parse("2016-07-24T20:34:12.999Z"), "+01:00"))
         .convertsFromExternal("[\"\",\"\"]")
-        .toInternal(tupleType.newValue(null, ""))
+        .toInternal(tupleType.newValue(null, null))
         .convertsFromExternal("[\"NULL\",\"NULL\"]")
         .toInternal(tupleType.newValue(null, null))
         .convertsFromExternal("[null,null]")

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToUUIDCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToUUIDCodecTest.java
@@ -53,8 +53,6 @@ class StringToUUIDCodecTest {
         .convertsFromExternal(null)
         .toInternal(null)
         .convertsFromExternal("NULL")
-        .toInternal(null)
-        .convertsFromExternal("")
         .toInternal(null);
 
     assertThat(new StringToUUIDCodec(TypeCodec.uuid(), instantCodec, MIN, nullStrings))
@@ -113,6 +111,6 @@ class StringToUUIDCodecTest {
 
   @Test
   void should_not_convert_from_invalid_external() {
-    assertThat(codec).cannotConvertFromExternal("not a valid UUID");
+    assertThat(codec).cannotConvertFromExternal("").cannotConvertFromExternal("not a valid UUID");
   }
 }

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToUnknownTypeCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToUnknownTypeCodecTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.string;
+
+import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
+import static com.google.common.collect.Lists.newArrayList;
+
+import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.ProtocolVersion;
+import com.datastax.driver.core.TypeCodec;
+import com.datastax.driver.core.exceptions.InvalidTypeException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Objects;
+import org.junit.jupiter.api.Test;
+
+public class StringToUnknownTypeCodecTest {
+
+  private FruitCodec targetCodec = new FruitCodec();
+  private List<String> nullStrings = newArrayList("NULL");
+  private Fruit banana = new Fruit("banana");
+
+  @Test
+  void should_convert_from_valid_external() {
+    StringToUnknownTypeCodec<Fruit> codec =
+        new StringToUnknownTypeCodec<>(targetCodec, nullStrings);
+    assertThat(codec)
+        .convertsFromExternal("banana")
+        .toInternal(banana)
+        .convertsFromExternal(null)
+        .toInternal(null)
+        .convertsFromExternal("NULL")
+        .toInternal(null);
+  }
+
+  @Test
+  void should_convert_from_valid_internal() {
+    StringToUnknownTypeCodec<Fruit> codec =
+        new StringToUnknownTypeCodec<>(targetCodec, nullStrings);
+    assertThat(codec).convertsFromInternal(banana).toExternal("banana");
+  }
+
+  @Test
+  void should_not_convert_from_invalid_external() {
+    StringToUnknownTypeCodec<Fruit> codec =
+        new StringToUnknownTypeCodec<>(targetCodec, nullStrings);
+    assertThat(codec)
+        .cannotConvertFromExternal("")
+        .cannotConvertFromExternal("not a valid fruit literal");
+  }
+
+  public static final DataType FRUIT_TYPE = DataType.custom("com.datastax.dse.FruitType");
+
+  public static class Fruit {
+
+    public final String name;
+
+    public Fruit(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Fruit fruit = (Fruit) o;
+      return Objects.equals(name, fruit.name);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name);
+    }
+  }
+
+  public static class FruitCodec extends TypeCodec<Fruit> {
+
+    public FruitCodec() {
+      super(FRUIT_TYPE, Fruit.class);
+    }
+
+    @Override
+    public Fruit parse(String value) throws InvalidTypeException {
+      if (value.equalsIgnoreCase("banana")) {
+        return new Fruit(value);
+      }
+      throw new InvalidTypeException("Unknown fruit: " + value);
+    }
+
+    @Override
+    public String format(Fruit value) throws InvalidTypeException {
+      return value.name;
+    }
+
+    @Override
+    public ByteBuffer serialize(Fruit value, ProtocolVersion protocolVersion)
+        throws InvalidTypeException {
+      throw new UnsupportedOperationException("irrelevant");
+    }
+
+    @Override
+    public Fruit deserialize(ByteBuffer bytes, ProtocolVersion protocolVersion)
+        throws InvalidTypeException {
+      throw new UnsupportedOperationException("irrelevant");
+    }
+  }
+}

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/dse/StringToDateRangeCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/dse/StringToDateRangeCodecTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.string.dse;
+
+import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
+import static com.google.common.collect.Lists.newArrayList;
+
+import com.datastax.driver.dse.search.DateRange;
+import java.text.ParseException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class StringToDateRangeCodecTest {
+
+  private List<String> nullStrings = newArrayList("NULL");
+  private DateRange dateRange = DateRange.parse("[* TO 2014-12-01]");
+
+  StringToDateRangeCodecTest() throws ParseException {}
+
+  @Test
+  void should_convert_from_valid_external() {
+
+    StringToDateRangeCodec codec = new StringToDateRangeCodec(nullStrings);
+    assertThat(codec)
+        .convertsFromExternal("[* TO 2014-12-01]")
+        .toInternal(dateRange)
+        .convertsFromExternal(null)
+        .toInternal(null)
+        .convertsFromExternal("NULL")
+        .toInternal(null);
+  }
+
+  @Test
+  void should_convert_from_valid_internal() {
+    StringToDateRangeCodec codec = new StringToDateRangeCodec(nullStrings);
+    assertThat(codec).convertsFromInternal(dateRange).toExternal("[* TO 2014-12-01]");
+  }
+
+  @Test
+  void should_not_convert_from_invalid_external() {
+    StringToDateRangeCodec codec = new StringToDateRangeCodec(nullStrings);
+    assertThat(codec)
+        .cannotConvertFromExternal("")
+        .cannotConvertFromExternal("not a valid date range literal");
+  }
+}

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/dse/StringToLineStringCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/dse/StringToLineStringCodecTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.string.dse;
+
+import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
+import static com.google.common.collect.Lists.newArrayList;
+
+import com.datastax.driver.dse.geometry.LineString;
+import com.datastax.driver.dse.geometry.Point;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class StringToLineStringCodecTest {
+
+  private List<String> nullStrings = newArrayList("NULL");
+  private LineString lineString =
+      new LineString(new Point(30, 10), new Point(10, 30), new Point(40, 40));
+
+  @Test
+  void should_convert_from_valid_external() {
+    StringToLineStringCodec codec = new StringToLineStringCodec(nullStrings);
+    assertThat(codec)
+        .convertsFromExternal("'LINESTRING (30 10, 10 30, 40 40)'")
+        .toInternal(lineString)
+        .convertsFromExternal(" linestring (30 10, 10 30, 40 40) ")
+        .toInternal(lineString)
+        .convertsFromExternal(
+            "{\"type\":\"LineString\",\"coordinates\":[[30.0,10.0],[10.0,30.0],[40.0,40.0]]}")
+        .toInternal(lineString)
+        .convertsFromExternal(null)
+        .toInternal(null)
+        .convertsFromExternal("NULL")
+        .toInternal(null);
+  }
+
+  @Test
+  void should_convert_from_valid_internal() {
+    StringToLineStringCodec codec = new StringToLineStringCodec(nullStrings);
+    assertThat(codec)
+        .convertsFromInternal(lineString)
+        .toExternal("LINESTRING (30 10, 10 30, 40 40)");
+  }
+
+  @Test
+  void should_not_convert_from_invalid_external() {
+    StringToLineStringCodec codec = new StringToLineStringCodec(nullStrings);
+    assertThat(codec)
+        .cannotConvertFromExternal("")
+        .cannotConvertFromExternal("not a valid linestring literal");
+  }
+}

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/dse/StringToPointCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/dse/StringToPointCodecTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.string.dse;
+
+import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
+import static com.google.common.collect.Lists.newArrayList;
+
+import com.datastax.driver.dse.geometry.Point;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class StringToPointCodecTest {
+
+  private List<String> nullStrings = newArrayList("NULL");
+  private Point point = new Point(-1.1, -2.2);
+
+  @Test
+  void should_convert_from_valid_external() {
+    StringToPointCodec codec = new StringToPointCodec(nullStrings);
+    assertThat(codec)
+        .convertsFromExternal("'POINT (-1.1 -2.2)'")
+        .toInternal(point)
+        .convertsFromExternal(" point (-1.1 -2.2) ")
+        .toInternal(point)
+        .convertsFromExternal("{\"type\":\"Point\",\"coordinates\":[-1.1,-2.2]}")
+        .toInternal(point)
+        .convertsFromExternal(null)
+        .toInternal(null)
+        .convertsFromExternal("NULL")
+        .toInternal(null);
+  }
+
+  @Test
+  void should_convert_from_valid_internal() {
+    StringToPointCodec codec = new StringToPointCodec(nullStrings);
+    assertThat(codec).convertsFromInternal(point).toExternal("POINT (-1.1 -2.2)");
+  }
+
+  @Test
+  void should_not_convert_from_invalid_external() {
+    StringToPointCodec codec = new StringToPointCodec(nullStrings);
+    assertThat(codec)
+        .cannotConvertFromExternal("")
+        .cannotConvertFromExternal("not a valid point literal");
+  }
+}

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/dse/StringToPolygonCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/dse/StringToPolygonCodecTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.string.dse;
+
+import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
+import static com.google.common.collect.Lists.newArrayList;
+
+import com.datastax.driver.dse.geometry.Point;
+import com.datastax.driver.dse.geometry.Polygon;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class StringToPolygonCodecTest {
+
+  private List<String> nullStrings = newArrayList("NULL");
+  private Polygon polygon =
+      new Polygon(new Point(30, 10), new Point(10, 20), new Point(20, 40), new Point(40, 40));
+
+  @Test
+  void should_convert_from_valid_external() {
+    StringToPolygonCodec codec = new StringToPolygonCodec(nullStrings);
+    assertThat(codec)
+        .convertsFromExternal("'POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))'")
+        .toInternal(polygon)
+        .convertsFromExternal(" polygon ((30 10, 40 40, 20 40, 10 20, 30 10)) ")
+        .toInternal(polygon)
+        .convertsFromExternal(
+            "{\"type\":\"Polygon\",\"coordinates\":[[[30.0,10.0],[10.0,20.0],[20.0,40.0],[40.0,40.0],[30.0,10.0]]]}")
+        .toInternal(polygon)
+        .convertsFromExternal(null)
+        .toInternal(null)
+        .convertsFromExternal("NULL")
+        .toInternal(null);
+  }
+
+  @Test
+  void should_convert_from_valid_internal() {
+    StringToPolygonCodec codec = new StringToPolygonCodec(nullStrings);
+    assertThat(codec)
+        .convertsFromInternal(polygon)
+        .toExternal("POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))");
+  }
+
+  @Test
+  void should_not_convert_from_invalid_external() {
+    StringToPolygonCodec codec = new StringToPolygonCodec(nullStrings);
+    assertThat(codec)
+        .cannotConvertFromExternal("")
+        .cannotConvertFromExternal("not a valid polygon literal");
+  }
+}

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/util/CodecUtilsTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/util/CodecUtilsTest.java
@@ -116,7 +116,6 @@ class CodecUtilsTest {
   @Test
   void should_parse_temporal_complex() {
     assertThat(parseTemporal(null, timestampFormat1, numberFormat1, MILLISECONDS, EPOCH)).isNull();
-    assertThat(parseTemporal("", timestampFormat1, numberFormat1, MILLISECONDS, EPOCH)).isNull();
     assertThat(
             Instant.from(
                 parseTemporal(
@@ -179,7 +178,6 @@ class CodecUtilsTest {
   @Test
   void should_parse_temporal() {
     assertThat(parseTemporal(null, timestampFormat1)).isNull();
-    assertThat(parseTemporal("", timestampFormat1)).isNull();
     assertThat(
             Instant.from(
                 parseTemporal("2017-11-23T13:24:59.000+01:00[Europe/Paris]", timestampFormat1)))
@@ -223,16 +221,6 @@ class CodecUtilsTest {
     assertThat(
             parseNumber(
                 null,
-                numberFormat1,
-                timestampFormat1,
-                MILLISECONDS,
-                EPOCH.atZone(UTC),
-                booleanInputWords,
-                booleanNumbers))
-        .isNull();
-    assertThat(
-            parseNumber(
-                "",
                 numberFormat1,
                 timestampFormat1,
                 MILLISECONDS,
@@ -1023,7 +1011,6 @@ class CodecUtilsTest {
             EPOCH.atZone(UTC),
             newArrayList("NULL"));
     assertThat(CodecUtils.parseUUID(null, instantCodec, MIN)).isNull();
-    assertThat(CodecUtils.parseUUID("", instantCodec, MIN)).isNull();
     assertThat(CodecUtils.parseUUID("a15341ec-ebef-4eab-b91d-ff16bf801a79", instantCodec, MIN))
         .isEqualTo(UUID.fromString("a15341ec-ebef-4eab-b91d-ff16bf801a79"));
     // time UUIDs with MIN strategy
@@ -1069,7 +1056,6 @@ class CodecUtilsTest {
     String data64 = Base64.getEncoder().encodeToString(data);
     String dataHex = Bytes.toHexString(data);
     assertThat(CodecUtils.parseByteBuffer(null)).isNull();
-    assertThat(CodecUtils.parseByteBuffer("")).isNull();
     assertThat(CodecUtils.parseByteBuffer("0x")).isEqualTo(ByteBuffer.wrap(new byte[] {}));
     assertThat(CodecUtils.parseByteBuffer(data64)).isEqualTo(ByteBuffer.wrap(data));
     assertThat(CodecUtils.parseByteBuffer(dataHex)).isEqualTo(ByteBuffer.wrap(data));


### PR DESCRIPTION
Summary of changes:

* DAT-266: add support for Geo types (Point, LineString and Polygon) as well as Search types (DateRange)
* Add support for unknown types (parsed and formatted using an existing compatible codec – strings are required to be valid CQL literals for the type)
* Fix problems related to null strings: in many places, the empty string was hard-coded as a null string, bypassing the user-specified option.
