### PR TITLE
DAT-268: Map-type settings unrecognized from the command-line

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -8,7 +8,7 @@
 - [improvement] DAT-251: Update DriverSettings with new TokenAwarePolicy.
 - [bug] DAT-259: LogManager files have interleaved entries.
 - [bug] DAT-260: LogManager is closing files too soon.
-
+- [bug] DAT=268: Map-type settings are unrecognized from the command-line.
 
 ### 1.0.1
 

--- a/connectors/csv/src/test/java/com/datastax/dsbulk/connectors/csv/CSVConnectorTest.java
+++ b/connectors/csv/src/test/java/com/datastax/dsbulk/connectors/csv/CSVConnectorTest.java
@@ -324,7 +324,7 @@ class CSVConnectorTest {
               "1999,Chevy,\"Venture \"\"Extended Edition, Very Large\"\"\",,5000.00",
               ",,\"Venture \"\"Extended Edition\"\"\",,4900.00");
     } finally {
-      deleteDirectory(out);
+      deleteDirectory(dir);
     }
   }
 

--- a/connectors/json/src/main/java/com/datastax/dsbulk/connectors/json/JsonConnector.java
+++ b/connectors/json/src/main/java/com/datastax/dsbulk/connectors/json/JsonConnector.java
@@ -39,7 +39,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.google.common.base.Suppliers;
+import com.typesafe.config.Config;
 import com.typesafe.config.ConfigException;
+import com.typesafe.config.ConfigFactory;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -159,14 +161,14 @@ public class JsonConnector implements Connector {
       maxConcurrentFiles = settings.getThreads(MAX_CONCURRENT_FILES);
       recursive = settings.getBoolean(RECURSIVE);
       fileNameFormat = settings.getString(FILE_NAME_FORMAT);
-      parserFeatures = getFeatureMap(settings.getConfig(PARSER_FEATURES), JsonParser.Feature.class);
+      parserFeatures = getFeatureMap(settings.getString(PARSER_FEATURES), JsonParser.Feature.class);
       generatorFeatures =
-          getFeatureMap(settings.getConfig(GENERATOR_FEATURES), JsonGenerator.Feature.class);
-      mapperFeatures = getFeatureMap(settings.getConfig(MAPPER_FEATURES), MapperFeature.class);
+          getFeatureMap(settings.getString(GENERATOR_FEATURES), JsonGenerator.Feature.class);
+      mapperFeatures = getFeatureMap(settings.getString(MAPPER_FEATURES), MapperFeature.class);
       serializationFeatures =
-          getFeatureMap(settings.getConfig(SERIALIZATION_FEATURES), SerializationFeature.class);
+          getFeatureMap(settings.getString(SERIALIZATION_FEATURES), SerializationFeature.class);
       deserializationFeatures =
-          getFeatureMap(settings.getConfig(DESERIALIZATION_FEATURES), DeserializationFeature.class);
+          getFeatureMap(settings.getString(DESERIALIZATION_FEATURES), DeserializationFeature.class);
       prettyPrint = settings.getBoolean(PRETTY_PRINT);
     } catch (ConfigException e) {
       throw ConfigUtils.configExceptionToBulkConfigurationException(e, "connector.json");
@@ -526,7 +528,8 @@ public class JsonConnector implements Connector {
   }
 
   private static <T extends Enum<T>> Map<T, Boolean> getFeatureMap(
-      LoaderConfig source, Class<T> featureClass) {
+      String sourceString, Class<T> featureClass) {
+    Config source = ConfigFactory.parseString(ConfigUtils.ensureBraces(sourceString));
     Map<T, Boolean> dest = new HashMap<>();
     for (String name : source.root().keySet()) {
       dest.put(Enum.valueOf(featureClass, name), source.getBoolean(name));

--- a/connectors/json/src/main/resources/reference.conf
+++ b/connectors/json/src/main/resources/reference.conf
@@ -63,29 +63,29 @@ dsbulk {
     # A map of JSON parser features to set. Map keys should be enum constants defined in `com.fasterxml.jackson.core.JsonParser.Feature`. For example, a value of `{ ALLOW_COMMENTS : true, ALLOW_SINGLE_QUOTES : true }` will configure the parser to allow the use of comments and single-quoted strings in JSON data. Used for loading only.
     # @leaf
     # @type map<string,boolean>
-    parserFeatures = {}
+    parserFeatures = "{}"
 
     # A map of JSON generator features to set. Map keys should be enum constants defined in `com.fasterxml.jackson.core.JsonGenerator.Feature`. For example, a value of `{ ESCAPE_NON_ASCII : true, QUOTE_FIELD_NAMES : true }` will configure the generator to escape all characters beyond 7-bit ASCII and quote field names when writing JSON output. Used for unloading only.
     # @leaf
     # @type map<string,boolean>
-    generatorFeatures = {}
+    generatorFeatures = "{}"
 
     # A map of JSON mapper features to set. Map keys should be enum constants defined in `com.fasterxml.jackson.databind.MapperFeature`. Used both for loading and unloading.
     # @leaf
     # @type map<string,boolean>
-    mapperFeatures = {}
+    mapperFeatures = "{}"
 
     # A map of JSON serialization features to set. Map keys should be enum constants defined in `com.fasterxml.jackson.databind.SerializationFeature`. Used for unloading only.
     # @leaf
     # @type map<string,boolean>
-    serializationFeatures = {}
+    serializationFeatures = "{}"
 
     # A map of JSON deserialization features to set. Map keys should be enum constants defined in `com.fasterxml.jackson.databind.DeserializationFeature`. Used for loading only.
     #
     # Note: the default is to set `USE_BIG_DECIMAL_FOR_FLOATS` to `true`; this is the only way to guarantee that floating point numbers will not have their precision truncated when parsed, at the cost of a slightly slower parsing.
     # @leaf
     # @type map<string,boolean>
-    deserializationFeatures = { USE_BIG_DECIMAL_FOR_FLOATS : true }
+    deserializationFeatures = "{USE_BIG_DECIMAL_FOR_FLOATS : true}"
 
     # Enable or disable pretty printing. When enabled, JSON records are written with indents. Used for unloading only.
     #

--- a/connectors/json/src/test/java/com/datastax/dsbulk/connectors/json/JsonConnectorTest.java
+++ b/connectors/json/src/test/java/com/datastax/dsbulk/connectors/json/JsonConnectorTest.java
@@ -69,8 +69,8 @@ class JsonConnectorTest {
         new DefaultLoaderConfig(
             ConfigFactory.parseString(
                     String.format(
-                        "url = \"%s\", parserFeatures = {ALLOW_COMMENTS:true}, "
-                            + "deserializationFeatures = {USE_BIG_DECIMAL_FOR_FLOATS : false}",
+                        "url = \"%s\", parserFeatures = \"{ALLOW_COMMENTS:true}\", "
+                            + "deserializationFeatures = \"{USE_BIG_DECIMAL_FOR_FLOATS : false}\"",
                         url("/multi_doc.json")))
                 .withFallback(CONNECTOR_DEFAULT_SETTINGS));
     connector.configure(settings, true);
@@ -87,8 +87,8 @@ class JsonConnectorTest {
         new DefaultLoaderConfig(
             ConfigFactory.parseString(
                     String.format(
-                        "url = \"%s\", parserFeatures = {ALLOW_COMMENTS:true}, "
-                            + "deserializationFeatures = {USE_BIG_DECIMAL_FOR_FLOATS : false}, "
+                        "url = \"%s\", parserFeatures = \"ALLOW_COMMENTS=true\", "
+                            + "deserializationFeatures = \"{USE_BIG_DECIMAL_FOR_FLOATS = false}\", "
                             + "mode = SINGLE_DOCUMENT",
                         url("/single_doc.json")))
                 .withFallback(CONNECTOR_DEFAULT_SETTINGS));
@@ -106,7 +106,7 @@ class JsonConnectorTest {
         new DefaultLoaderConfig(
             ConfigFactory.parseString(
                     String.format(
-                        "url = \"%s\", parserFeatures = {ALLOW_COMMENTS:true}, mode = SINGLE_DOCUMENT",
+                        "url = \"%s\", parserFeatures = \"{ALLOW_COMMENTS:true}\", mode = SINGLE_DOCUMENT",
                         url("/empty.json")))
                 .withFallback(CONNECTOR_DEFAULT_SETTINGS));
     connector.configure(settings, true);
@@ -124,7 +124,7 @@ class JsonConnectorTest {
         new DefaultLoaderConfig(
             ConfigFactory.parseString(
                     String.format(
-                        "url = \"%s\", parserFeatures = {ALLOW_COMMENTS:true}, mode = MULTI_DOCUMENT",
+                        "url = \"%s\", parserFeatures = \"{ALLOW_COMMENTS:true}\", mode = MULTI_DOCUMENT",
                         url("/empty.json")))
                 .withFallback(CONNECTOR_DEFAULT_SETTINGS));
     connector.configure(settings, true);
@@ -142,8 +142,8 @@ class JsonConnectorTest {
         new DefaultLoaderConfig(
             ConfigFactory.parseString(
                     String.format(
-                        "url = \"%s\", parserFeatures = {ALLOW_COMMENTS:true}, "
-                            + "deserializationFeatures = {USE_BIG_DECIMAL_FOR_FLOATS : false}",
+                        "url = \"%s\", parserFeatures = \"{ALLOW_COMMENTS:true}\", "
+                            + "deserializationFeatures = \"{USE_BIG_DECIMAL_FOR_FLOATS : false}\"",
                         url("/multi_doc.json")))
                 .withFallback(CONNECTOR_DEFAULT_SETTINGS));
     connector.configure(settings, true);
@@ -331,7 +331,7 @@ class JsonConnectorTest {
               "{\"Year\":1999,\"Make\":\"Chevy\",\"Model\":\"Venture \\\"Extended Edition, Very Large\\\"\",\"Description\":null,\"Price\":5000.0}",
               "{\"Year\":null,\"Make\":null,\"Model\":\"Venture \\\"Extended Edition\\\"\",\"Description\":null,\"Price\":4900.0}");
     } finally {
-      deleteDirectory(out);
+      deleteDirectory(dir);
     }
   }
 
@@ -366,7 +366,7 @@ class JsonConnectorTest {
               "{\"Year\":null,\"Make\":null,\"Model\":\"Venture \\\"Extended Edition\\\"\",\"Description\":null,\"Price\":4900.0}",
               "]");
     } finally {
-      deleteDirectory(out);
+      deleteDirectory(dir);
     }
   }
 
@@ -615,7 +615,7 @@ class JsonConnectorTest {
         new DefaultLoaderConfig(
             ConfigFactory.parseString(
                     String.format(
-                        "url = \"%s\", parserFeatures = {ALLOW_COMMENTS:true}, mode = MULTI_DOCUMENT",
+                        "url = \"%s\", parserFeatures = \"{ALLOW_COMMENTS:true}\", mode = MULTI_DOCUMENT",
                         url("/single_doc.json")))
                 .withFallback(CONNECTOR_DEFAULT_SETTINGS));
     connector.configure(settings, true);
@@ -643,8 +643,8 @@ class JsonConnectorTest {
                       String.format(
                           "url = \"http://localhost:%d/file.json\", "
                               + "mode = SINGLE_DOCUMENT, "
-                              + "parserFeatures = {ALLOW_COMMENTS:true}, "
-                              + "deserializationFeatures = {USE_BIG_DECIMAL_FOR_FLOATS : false}",
+                              + "parserFeatures = \"{ALLOW_COMMENTS:true}\", "
+                              + "deserializationFeatures = \"{USE_BIG_DECIMAL_FOR_FLOATS : false}\"",
                           server.getPort()))
                   .withFallback(CONNECTOR_DEFAULT_SETTINGS));
       connector.configure(settings, true);

--- a/engine/src/main/java/com/datastax/dsbulk/engine/DataStaxBulkLoader.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/DataStaxBulkLoader.java
@@ -74,7 +74,7 @@ public class DataStaxBulkLoader {
       // The first arg can be a subcommand or option...or no arg. We want to treat these
       // cases as follows:
       // no arg: same as help subcommand with no connectorName name.
-      // first arg that is a short/long option: all args are short/long options (no subcommand).
+      // first arg is a short/long option: all args are short/long options (no subcommand).
       // first arg is not a short/long option: first arg is a subcommand, rest are options.
 
       String[] optionArgs;

--- a/engine/src/test/java/com/datastax/dsbulk/engine/DataStaxBulkLoaderTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/DataStaxBulkLoaderTest.java
@@ -27,6 +27,7 @@ import com.datastax.dsbulk.commons.tests.logging.StreamInterceptingExtension;
 import com.datastax.dsbulk.commons.tests.logging.StreamInterceptor;
 import com.datastax.dsbulk.engine.internal.utils.HelpUtils;
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
@@ -546,6 +547,68 @@ class DataStaxBulkLoaderTest {
     assertThat(result.getInt("connector.json.maxRecords")).isEqualTo(111);
     assertThat(result.getInt("connector.json.maxConcurrentFiles")).isEqualTo(222);
     assertThat(result.getString("connector.json.url")).isEqualTo("http://findit");
+  }
+
+  @Test
+  void should_process_json_long_options() throws Exception {
+    DataStaxBulkLoader.DEFAULT = ConfigFactory.load().getConfig("dsbulk");
+    Config result =
+        DataStaxBulkLoader.parseCommandLine(
+            "load",
+            new String[] {
+              "-c",
+              "json",
+              "--connector.json.url",
+              "url",
+              "--connector.json.mode",
+              "SINGLE_DOCUMENT",
+              "--connector.json.fileNamePattern",
+              "pat",
+              "--connector.json.fileNameFormat",
+              "fmt",
+              "--connector.json.recursive",
+              "true",
+              "--connector.json.maxConcurrentFiles",
+              "1",
+              "--connector.json.encoding",
+              "enc",
+              "--connector.json.skipRecords",
+              "2",
+              "--connector.json.maxRecords",
+              "3",
+              "--connector.json.parserFeatures",
+              "{f1 = true, f2 = false}",
+              "--connector.json.generatorFeatures",
+              "{g1 = true, g2 = false}",
+              "--connector.json.mapperFeatures",
+              "{m1 = true, m2 = false}",
+              "--connector.json.serializationFeatures",
+              "{s1 = true, s2 = false}",
+              "--connector.json.deserializationFeatures",
+              "{d1 = true, d2 = false}",
+              "--connector.json.prettyPrint",
+              "true",
+            });
+    assertThat(result.getString("connector.json.url")).isEqualTo("url");
+    assertThat(result.getString("connector.json.mode")).isEqualTo("SINGLE_DOCUMENT");
+    assertThat(result.getString("connector.json.fileNamePattern")).isEqualTo("pat");
+    assertThat(result.getString("connector.json.fileNameFormat")).isEqualTo("fmt");
+    assertThat(result.getBoolean("connector.json.recursive")).isTrue();
+    assertThat(result.getInt("connector.json.maxConcurrentFiles")).isEqualTo(1);
+    assertThat(result.getString("connector.json.encoding")).isEqualTo("enc");
+    assertThat(result.getInt("connector.json.skipRecords")).isEqualTo(2);
+    assertThat(result.getInt("connector.json.maxRecords")).isEqualTo(3);
+    assertThat(result.getString("connector.json.parserFeatures"))
+        .isEqualTo("{f1 = true, f2 = false}");
+    assertThat(result.getString("connector.json.generatorFeatures"))
+        .isEqualTo("{g1 = true, g2 = false}");
+    assertThat(result.getString("connector.json.mapperFeatures"))
+        .isEqualTo("{m1 = true, m2 = false}");
+    assertThat(result.getString("connector.json.serializationFeatures"))
+        .isEqualTo("{s1 = true, s2 = false}");
+    assertThat(result.getString("connector.json.deserializationFeatures"))
+        .isEqualTo("{d1 = true, d2 = false}");
+    assertThat(result.getBoolean("connector.json.prettyPrint")).isTrue();
   }
 
   @Test

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/settings/ConnectorSettingsTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/settings/ConnectorSettingsTest.java
@@ -72,8 +72,6 @@ class ConnectorSettingsTest {
             "encoding",
             "skipRecords",
             "maxRecords",
-            "parserFeatures",
-            "generatorFeatures",
             "prettyPrint")
         .doesNotHavePath("json");
   }

--- a/manual/application.template.conf
+++ b/manual/application.template.conf
@@ -249,8 +249,8 @@ dsbulk {
     # guarantee that floating point numbers will not have their precision truncated when parsed, at
     # the cost of a slightly slower parsing.
     # Type: map<string,boolean>
-    # Default value: {"USE_BIG_DECIMAL_FOR_FLOATS":true}
-    #connector.json.deserializationFeatures = {"USE_BIG_DECIMAL_FOR_FLOATS":true}
+    # Default value: "{USE_BIG_DECIMAL_FOR_FLOATS : true}"
+    #connector.json.deserializationFeatures = "{USE_BIG_DECIMAL_FOR_FLOATS : true}"
 
     # The file encoding to use for all read or written files.
     # Type: string
@@ -278,14 +278,14 @@ dsbulk {
     # all characters beyond 7-bit ASCII and quote field names when writing JSON output. Used for
     # unloading only.
     # Type: map<string,boolean>
-    # Default value: {}
-    #connector.json.generatorFeatures = {}
+    # Default value: "{}"
+    #connector.json.generatorFeatures = "{}"
 
     # A map of JSON mapper features to set. Map keys should be enum constants defined in
     # `com.fasterxml.jackson.databind.MapperFeature`. Used both for loading and unloading.
     # Type: map<string,boolean>
-    # Default value: {}
-    #connector.json.mapperFeatures = {}
+    # Default value: "{}"
+    #connector.json.mapperFeatures = "{}"
 
     # The maximum number of files that can be written simultaneously. This setting is ignored when
     # reading and when the output URL is anything other than a directory on a filesystem. The
@@ -300,8 +300,8 @@ dsbulk {
     # true, ALLOW_SINGLE_QUOTES : true }` will configure the parser to allow the use of comments and
     # single-quoted strings in JSON data. Used for loading only.
     # Type: map<string,boolean>
-    # Default value: {}
-    #connector.json.parserFeatures = {}
+    # Default value: "{}"
+    #connector.json.parserFeatures = "{}"
 
     # Enable or disable pretty printing. When enabled, JSON records are written with indents. Used
     # for unloading only.
@@ -320,8 +320,8 @@ dsbulk {
     # A map of JSON serialization features to set. Map keys should be enum constants defined in
     # `com.fasterxml.jackson.databind.SerializationFeature`. Used for unloading only.
     # Type: map<string,boolean>
-    # Default value: {}
-    #connector.json.serializationFeatures = {}
+    # Default value: "{}"
+    #connector.json.serializationFeatures = "{}"
 
     ################################################################################################
     # Schema-specific settings.

--- a/manual/settings.md
+++ b/manual/settings.md
@@ -424,6 +424,8 @@ A map of JSON deserialization features to set. Map keys should be enum constants
 
 Note: the default is to set `USE_BIG_DECIMAL_FOR_FLOATS` to `true`; this is the only way to guarantee that floating point numbers will not have their precision truncated when parsed, at the cost of a slightly slower parsing.
 
+Default: **"{USE_BIG_DECIMAL_FOR_FLOATS : true}"**.
+
 #### -encoding,--connector.json.encoding _&lt;string&gt;_
 
 The file encoding to use for all read or written files.
@@ -446,9 +448,13 @@ Default: **"\*\*/\*.json"**.
 
 A map of JSON generator features to set. Map keys should be enum constants defined in `com.fasterxml.jackson.core.JsonGenerator.Feature`. For example, a value of `{ ESCAPE_NON_ASCII : true, QUOTE_FIELD_NAMES : true }` will configure the generator to escape all characters beyond 7-bit ASCII and quote field names when writing JSON output. Used for unloading only.
 
+Default: **"{}"**.
+
 #### --connector.json.mapperFeatures _&lt;map&lt;string,boolean&gt;&gt;_
 
 A map of JSON mapper features to set. Map keys should be enum constants defined in `com.fasterxml.jackson.databind.MapperFeature`. Used both for loading and unloading.
+
+Default: **"{}"**.
 
 #### -maxConcurrentFiles,--connector.json.maxConcurrentFiles _&lt;string&gt;_
 
@@ -459,6 +465,8 @@ Default: **"0.25C"**.
 #### --connector.json.parserFeatures _&lt;map&lt;string,boolean&gt;&gt;_
 
 A map of JSON parser features to set. Map keys should be enum constants defined in `com.fasterxml.jackson.core.JsonParser.Feature`. For example, a value of `{ ALLOW_COMMENTS : true, ALLOW_SINGLE_QUOTES : true }` will configure the parser to allow the use of comments and single-quoted strings in JSON data. Used for loading only.
+
+Default: **"{}"**.
 
 #### --connector.json.prettyPrint _&lt;boolean&gt;_
 
@@ -477,6 +485,8 @@ Default: **false**.
 #### --connector.json.serializationFeatures _&lt;map&lt;string,boolean&gt;&gt;_
 
 A map of JSON serialization features to set. Map keys should be enum constants defined in `com.fasterxml.jackson.databind.SerializationFeature`. Used for unloading only.
+
+Default: **"{}"**.
 
 <a name="schema"></a>
 ## Schema Settings


### PR DESCRIPTION
* Change json.parserFeatures, generatorFeatures, mappingFeatures,
  serializationFeatures, and deserializationFeatures into string
  settings, to be interpreted as maps.
* Fix incorrect temp dir cleaning for some json and csv connector tests.