### PR TITLE
DAT-270: Replace Java collections with JCTools equivalents whenever possible.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -9,6 +9,7 @@
 - [bug] DAT-259: LogManager files have interleaved entries.
 - [bug] DAT-260: LogManager is closing files too soon.
 - [bug] DAT-266: DSE Geometry types cause CodecNotFoundException.
+- [improvement] DAT-270: Replace Java collections with JCTools equivalents whenever possible.
 
 
 ### 1.0.1

--- a/commons/src/main/java/com/datastax/dsbulk/commons/internal/concurrent/ScalableThreadPoolExecutor.java
+++ b/commons/src/main/java/com/datastax/dsbulk/commons/internal/concurrent/ScalableThreadPoolExecutor.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.commons.internal.concurrent;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TransferQueue;
+
+/**
+ * A scalable {@link ThreadPoolExecutor} that favors spawning new threads over enqueuing tasks.
+ *
+ * @see <a href="https://dzone.com/articles/scalable-java-thread-pool-executor">A Scalable Java
+ *     Thread Pool Executor</a>
+ */
+public class ScalableThreadPoolExecutor extends ThreadPoolExecutor {
+
+  /**
+   * Creates a new scalable thread pool.
+   *
+   * @param corePoolSize the core pool size.
+   * @param maximumPoolSize the maximum pool size.
+   * @param keepAliveTime the keep-alive time.
+   * @param keepAliveUnit the keep-alive unit.
+   */
+  public ScalableThreadPoolExecutor(
+      int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit keepAliveUnit) {
+    super(
+        corePoolSize,
+        maximumPoolSize,
+        keepAliveTime,
+        keepAliveUnit,
+        new InterceptingQueue<>(),
+        // Add rejected work to the queue
+        (r, e) -> e.getQueue().add(r));
+  }
+
+  @Override
+  public void setRejectedExecutionHandler(RejectedExecutionHandler handler) {
+    throw new UnsupportedOperationException("Cannot set rejected execution handler");
+  }
+
+  private static class InterceptingQueue<E> implements TransferQueue<E> {
+
+    private final TransferQueue<E> delegate = new LinkedTransferQueue<>();
+
+    @Override
+    public boolean offer(E o) {
+      // intercept calls to offer() and try to transfer the work directly to an available thread.
+      // If this fails, the executor will spawn a new thread if possible. If a new thread could not
+      // be created, the rejected execution handler above will be invoked and the element will be
+      // enqueued for later execution.
+      return tryTransfer(o);
+    }
+
+    @Override
+    public boolean offer(E e, long timeout, TimeUnit unit) throws InterruptedException {
+      return tryTransfer(e, timeout, unit);
+    }
+
+    @Override
+    public boolean add(E o) {
+      return this.delegate.add(o);
+    }
+
+    @Override
+    public void put(E e) throws InterruptedException {
+      this.delegate.put(e);
+    }
+
+    @Override
+    public E poll() {
+      return this.delegate.poll();
+    }
+
+    @Override
+    public E poll(long timeout, TimeUnit unit) throws InterruptedException {
+      return this.delegate.poll(timeout, unit);
+    }
+
+    @Override
+    public E take() throws InterruptedException {
+      return this.delegate.take();
+    }
+
+    @Override
+    public E remove() {
+      return this.delegate.remove();
+    }
+
+    @Override
+    public boolean remove(Object o) {
+      return this.delegate.remove(o);
+    }
+
+    @Override
+    public E peek() {
+      return this.delegate.peek();
+    }
+
+    @Override
+    public E element() {
+      return this.delegate.element();
+    }
+
+    @Override
+    public int size() {
+      return this.delegate.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return this.delegate.isEmpty();
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+      return this.delegate.iterator();
+    }
+
+    @Override
+    public Object[] toArray() {
+      return this.delegate.toArray();
+    }
+
+    @SuppressWarnings("SuspiciousToArrayCall")
+    @Override
+    public <T> T[] toArray(T[] a) {
+      return this.delegate.toArray(a);
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+      return this.delegate.containsAll(c);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+      return this.delegate.addAll(c);
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+      return this.delegate.removeAll(c);
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+      return this.delegate.retainAll(c);
+    }
+
+    @Override
+    public void clear() {
+      this.delegate.clear();
+    }
+
+    @Override
+    public int remainingCapacity() {
+      return this.delegate.remainingCapacity();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+      return this.delegate.contains(o);
+    }
+
+    @Override
+    public int drainTo(Collection<? super E> c) {
+      return this.delegate.drainTo(c);
+    }
+
+    @Override
+    public int drainTo(Collection<? super E> c, int maxElements) {
+      return this.delegate.drainTo(c, maxElements);
+    }
+
+    @Override
+    public boolean tryTransfer(E e) {
+      return this.delegate.tryTransfer(e);
+    }
+
+    @Override
+    public void transfer(E e) throws InterruptedException {
+      this.delegate.transfer(e);
+    }
+
+    @Override
+    public boolean tryTransfer(E e, long timeout, TimeUnit unit) throws InterruptedException {
+      return this.delegate.tryTransfer(e, timeout, unit);
+    }
+
+    @Override
+    public boolean hasWaitingConsumer() {
+      return this.delegate.hasWaitingConsumer();
+    }
+
+    @Override
+    public int getWaitingConsumerCount() {
+      return this.delegate.getWaitingConsumerCount();
+    }
+  }
+}

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/log/statement/StatementPrinterRegistry.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/log/statement/StatementPrinterRegistry.java
@@ -18,8 +18,8 @@ import com.datastax.dsbulk.engine.internal.statement.BulkBoundStatement;
 import com.datastax.dsbulk.engine.internal.statement.BulkSimpleStatement;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import org.jctools.maps.NonBlockingHashMap;
 
 /**
  * A registry for {@link StatementPrinter statement printers}.
@@ -40,7 +40,7 @@ public final class StatementPrinterRegistry {
           .put(Statement.class, new DefaultStatementPrinter())
           .build();
 
-  private final ConcurrentMap<Class<?>, StatementPrinter<?>> printers = new ConcurrentHashMap<>();
+  private final ConcurrentMap<Class<?>, StatementPrinter<?>> printers = new NonBlockingHashMap<>();
 
   StatementPrinterRegistry() {}
 
@@ -56,7 +56,9 @@ public final class StatementPrinterRegistry {
    */
   public StatementPrinter<Statement> findPrinter(Class<?> statementClass) {
     StatementPrinter<?> printer = lookupPrinter(statementClass, printers);
-    if (printer == null) printer = lookupPrinter(statementClass, BUILT_IN_PRINTERS);
+    if (printer == null) {
+      printer = lookupPrinter(statementClass, BUILT_IN_PRINTERS);
+    }
     assert printer != null;
     @SuppressWarnings("unchecked")
     StatementPrinter<Statement> sp = (StatementPrinter<Statement>) printer;

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/metrics/MetricsManager.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/metrics/MetricsManager.java
@@ -35,6 +35,7 @@ import com.datastax.dsbulk.executor.api.listener.MetricsCollectingExecutionListe
 import com.datastax.dsbulk.executor.api.listener.ReadsReportingExecutionListener;
 import com.datastax.dsbulk.executor.api.listener.WritesReportingExecutionListener;
 import com.datastax.dsbulk.executor.api.result.Result;
+import com.google.common.util.concurrent.MoreExecutors;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 import java.nio.file.Path;
@@ -329,11 +330,9 @@ public class MetricsManager implements AutoCloseable {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     closeReporters();
-    scheduler.shutdown();
-    scheduler.awaitTermination(1, MINUTES);
-    scheduler.shutdownNow();
+    MoreExecutors.shutdownAndAwaitTermination(scheduler, 1, MINUTES);
     tearDownMetricsLogger();
   }
 

--- a/executor/api/src/main/java/com/datastax/dsbulk/executor/api/internal/listener/DefaultExecutionContext.java
+++ b/executor/api/src/main/java/com/datastax/dsbulk/executor/api/internal/listener/DefaultExecutionContext.java
@@ -10,8 +10,8 @@ package com.datastax.dsbulk.executor.api.internal.listener;
 
 import com.datastax.dsbulk.executor.api.listener.ExecutionContext;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import org.jctools.maps.NonBlockingHashMap;
 
 public class DefaultExecutionContext implements ExecutionContext {
 
@@ -49,7 +49,7 @@ public class DefaultExecutionContext implements ExecutionContext {
       synchronized (this) {
         if (attributes == null) {
           @SuppressWarnings("UnnecessaryLocalVariable")
-          ConcurrentMap<Object, Object> attributes = new ConcurrentHashMap<>();
+          ConcurrentMap<Object, Object> attributes = new NonBlockingHashMap<>();
           this.attributes = attributes;
         }
       }


### PR DESCRIPTION
This commit also replaces LogManager's internal executor with a special
ThreadPoolExecutor that favors spawning new threads over enqueuing tasks,
thus achieving the desired goal of having an initial pool size of 1,
but allowing it to grow up to 8 threads.

Finally, this commit also replaces manual ExeuctorService shutdown
procedures with Guava's MoreExecutors.shutdownAndAwaitTermination().