### PR TITLE
DAT-277: Support all CQL literal formats

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -17,6 +17,7 @@
 - [bug] DAT-273: Json connector doesn't respect WRITE_NULL_MAP_VALUES in serialization features setting.
 - [improvement] DAT-275: Simplify schema.queryTimestamp format.
 - [improvement] DAT-276: Remove connector.json.mapperFeatures setting.
+- [improvement] DAT-277: Support all CQL literal formats.
 
 
 ### 1.0.1

--- a/engine/src/it/resources/temporal.csv
+++ b/engine/src/it/resources/temporal.csv
@@ -1,2 +1,2 @@
-key,vdate                 ,vtime    ,vtimestamp                                 ,vseconds
+key,vdate                  ,vtime    ,vtimestamp                                 ,vseconds
 0  ,"vendredi, 9 mars 2018",171232584,2018-03-09T17:12:32.584+01:00[Europe/Paris],1520611952

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBigDecimalCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBigDecimalCodec.java
@@ -13,13 +13,14 @@ import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NO
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.CodecUtils;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -30,7 +31,8 @@ public class JsonNodeToBigDecimalCodec extends JsonNodeToNumberCodec<BigDecimal>
       FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
-      DateTimeFormatter temporalFormat,
+      TemporalFormat temporalFormat,
+      ZoneId timeZone,
       TimeUnit timeUnit,
       ZonedDateTime epoch,
       Map<String, Boolean> booleanStrings,
@@ -42,6 +44,7 @@ public class JsonNodeToBigDecimalCodec extends JsonNodeToNumberCodec<BigDecimal>
         overflowStrategy,
         roundingMode,
         temporalFormat,
+        timeZone,
         timeUnit,
         epoch,
         booleanStrings,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBigIntegerCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBigIntegerCodec.java
@@ -13,14 +13,15 @@ import static java.util.stream.Collectors.toList;
 
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -31,7 +32,8 @@ public class JsonNodeToBigIntegerCodec extends JsonNodeToNumberCodec<BigInteger>
       FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
-      DateTimeFormatter temporalFormat,
+      TemporalFormat temporalFormat,
+      ZoneId timeZone,
       TimeUnit timeUnit,
       ZonedDateTime epoch,
       Map<String, Boolean> booleanStrings,
@@ -43,6 +45,7 @@ public class JsonNodeToBigIntegerCodec extends JsonNodeToNumberCodec<BigInteger>
         overflowStrategy,
         roundingMode,
         temporalFormat,
+        timeZone,
         timeUnit,
         epoch,
         booleanStrings,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToByteCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToByteCodec.java
@@ -13,13 +13,14 @@ import static java.util.stream.Collectors.toList;
 
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -30,7 +31,8 @@ public class JsonNodeToByteCodec extends JsonNodeToNumberCodec<Byte> {
       FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
-      DateTimeFormatter temporalFormat,
+      TemporalFormat temporalFormat,
+      ZoneId timeZone,
       TimeUnit timeUnit,
       ZonedDateTime epoch,
       Map<String, Boolean> booleanStrings,
@@ -42,6 +44,7 @@ public class JsonNodeToByteCodec extends JsonNodeToNumberCodec<Byte> {
         overflowStrategy,
         roundingMode,
         temporalFormat,
+        timeZone,
         timeUnit,
         epoch,
         booleanStrings,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToDoubleCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToDoubleCodec.java
@@ -13,13 +13,14 @@ import static java.util.stream.Collectors.toList;
 
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -30,7 +31,8 @@ public class JsonNodeToDoubleCodec extends JsonNodeToNumberCodec<Double> {
       FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
-      DateTimeFormatter temporalFormat,
+      TemporalFormat temporalFormat,
+      ZoneId timeZone,
       TimeUnit timeUnit,
       ZonedDateTime epoch,
       Map<String, Boolean> booleanStrings,
@@ -42,6 +44,7 @@ public class JsonNodeToDoubleCodec extends JsonNodeToNumberCodec<Double> {
         overflowStrategy,
         roundingMode,
         temporalFormat,
+        timeZone,
         timeUnit,
         epoch,
         booleanStrings,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToFloatCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToFloatCodec.java
@@ -13,13 +13,14 @@ import static java.util.stream.Collectors.toList;
 
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -30,7 +31,8 @@ public class JsonNodeToFloatCodec extends JsonNodeToNumberCodec<Float> {
       FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
-      DateTimeFormatter temporalFormat,
+      TemporalFormat temporalFormat,
+      ZoneId timeZone,
       TimeUnit timeUnit,
       ZonedDateTime epoch,
       Map<String, Boolean> booleanStrings,
@@ -42,6 +44,7 @@ public class JsonNodeToFloatCodec extends JsonNodeToNumberCodec<Float> {
         overflowStrategy,
         roundingMode,
         temporalFormat,
+        timeZone,
         timeUnit,
         epoch,
         booleanStrings,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToInstantCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToInstantCodec.java
@@ -10,12 +10,13 @@ package com.datastax.dsbulk.engine.internal.codecs.json;
 
 import com.datastax.driver.extras.codecs.jdk8.InstantCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.CodecUtils;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.text.NumberFormat;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -23,17 +24,20 @@ import java.util.concurrent.TimeUnit;
 public class JsonNodeToInstantCodec extends JsonNodeToTemporalCodec<Instant> {
 
   private final FastThreadLocal<NumberFormat> numberFormat;
+  private final ZoneId timeZone;
   private final TimeUnit timeUnit;
   private final ZonedDateTime epoch;
 
   public JsonNodeToInstantCodec(
-      DateTimeFormatter temporalFormat,
+      TemporalFormat temporalFormat,
       FastThreadLocal<NumberFormat> numberFormat,
+      ZoneId timeZone,
       TimeUnit timeUnit,
       ZonedDateTime epoch,
       List<String> nullStrings) {
     super(InstantCodec.instance, temporalFormat, nullStrings);
     this.numberFormat = numberFormat;
+    this.timeZone = timeZone;
     this.timeUnit = timeUnit;
     this.epoch = epoch;
   }
@@ -44,8 +48,7 @@ public class JsonNodeToInstantCodec extends JsonNodeToTemporalCodec<Instant> {
     if (temporal == null) {
       return null;
     }
-    return CodecUtils.convertTemporal(
-        temporal, Instant.class, temporalFormat.getZone(), epoch.toLocalDate());
+    return CodecUtils.convertTemporal(temporal, Instant.class, timeZone, epoch.toLocalDate());
   }
 
   @Override

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToIntegerCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToIntegerCodec.java
@@ -13,13 +13,14 @@ import static java.util.stream.Collectors.toList;
 
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -30,7 +31,8 @@ public class JsonNodeToIntegerCodec extends JsonNodeToNumberCodec<Integer> {
       FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
-      DateTimeFormatter temporalFormat,
+      TemporalFormat temporalFormat,
+      ZoneId timeZone,
       TimeUnit timeUnit,
       ZonedDateTime epoch,
       Map<String, Boolean> booleanStrings,
@@ -42,6 +44,7 @@ public class JsonNodeToIntegerCodec extends JsonNodeToNumberCodec<Integer> {
         overflowStrategy,
         roundingMode,
         temporalFormat,
+        timeZone,
         timeUnit,
         epoch,
         booleanStrings,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToLocalDateCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToLocalDateCodec.java
@@ -10,16 +10,16 @@ package com.datastax.dsbulk.engine.internal.codecs.json;
 
 import com.datastax.driver.core.exceptions.InvalidTypeException;
 import com.datastax.driver.extras.codecs.jdk8.LocalDateCodec;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.time.DateTimeException;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.List;
 
 public class JsonNodeToLocalDateCodec extends JsonNodeToTemporalCodec<LocalDate> {
 
-  public JsonNodeToLocalDateCodec(DateTimeFormatter parser, List<String> nullStrings) {
+  public JsonNodeToLocalDateCodec(TemporalFormat parser, List<String> nullStrings) {
     super(LocalDateCodec.instance, parser, nullStrings);
   }
 

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToLocalTimeCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToLocalTimeCodec.java
@@ -10,16 +10,16 @@ package com.datastax.dsbulk.engine.internal.codecs.json;
 
 import com.datastax.driver.core.exceptions.InvalidTypeException;
 import com.datastax.driver.extras.codecs.jdk8.LocalTimeCodec;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.time.DateTimeException;
 import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.List;
 
 public class JsonNodeToLocalTimeCodec extends JsonNodeToTemporalCodec<LocalTime> {
 
-  public JsonNodeToLocalTimeCodec(DateTimeFormatter parser, List<String> nullStrings) {
+  public JsonNodeToLocalTimeCodec(TemporalFormat parser, List<String> nullStrings) {
     super(LocalTimeCodec.instance, parser, nullStrings);
   }
 

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToLongCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToLongCodec.java
@@ -13,13 +13,14 @@ import static java.util.stream.Collectors.toList;
 
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -30,7 +31,8 @@ public class JsonNodeToLongCodec extends JsonNodeToNumberCodec<Long> {
       FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
-      DateTimeFormatter temporalFormat,
+      TemporalFormat temporalFormat,
+      ZoneId timeZone,
       TimeUnit timeUnit,
       ZonedDateTime epoch,
       Map<String, Boolean> booleanStrings,
@@ -42,6 +44,7 @@ public class JsonNodeToLongCodec extends JsonNodeToNumberCodec<Long> {
         overflowStrategy,
         roundingMode,
         temporalFormat,
+        timeZone,
         timeUnit,
         epoch,
         booleanStrings,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToNumberCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToNumberCodec.java
@@ -11,12 +11,13 @@ package com.datastax.dsbulk.engine.internal.codecs.json;
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.CodecUtils;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -26,7 +27,8 @@ abstract class JsonNodeToNumberCodec<N extends Number> extends JsonNodeConvertin
   private final FastThreadLocal<NumberFormat> numberFormat;
   private final OverflowStrategy overflowStrategy;
   private final RoundingMode roundingMode;
-  private final DateTimeFormatter temporalFormat;
+  private final TemporalFormat temporalFormat;
+  private final ZoneId timeZone;
   private final TimeUnit timeUnit;
   private final ZonedDateTime epoch;
   private final Map<String, Boolean> booleanStrings;
@@ -37,7 +39,8 @@ abstract class JsonNodeToNumberCodec<N extends Number> extends JsonNodeConvertin
       FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
-      DateTimeFormatter temporalFormat,
+      TemporalFormat temporalFormat,
+      ZoneId timeZone,
       TimeUnit timeUnit,
       ZonedDateTime epoch,
       Map<String, Boolean> booleanStrings,
@@ -48,6 +51,7 @@ abstract class JsonNodeToNumberCodec<N extends Number> extends JsonNodeConvertin
     this.overflowStrategy = overflowStrategy;
     this.roundingMode = roundingMode;
     this.temporalFormat = temporalFormat;
+    this.timeZone = timeZone;
     this.timeUnit = timeUnit;
     this.epoch = epoch;
     this.booleanStrings = booleanStrings;
@@ -62,6 +66,7 @@ abstract class JsonNodeToNumberCodec<N extends Number> extends JsonNodeConvertin
         node.asText(),
         numberFormat.get(),
         temporalFormat,
+        timeZone,
         timeUnit,
         epoch,
         booleanStrings,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToShortCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToShortCodec.java
@@ -12,13 +12,14 @@ import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NO
 import static java.util.stream.Collectors.toList;
 
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -29,7 +30,8 @@ public class JsonNodeToShortCodec extends JsonNodeToNumberCodec<Short> {
       FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
-      DateTimeFormatter temporalFormat,
+      TemporalFormat temporalFormat,
+      ZoneId timeZone,
       TimeUnit timeUnit,
       ZonedDateTime epoch,
       Map<String, Boolean> booleanStrings,
@@ -41,6 +43,7 @@ public class JsonNodeToShortCodec extends JsonNodeToNumberCodec<Short> {
         overflowStrategy,
         roundingMode,
         temporalFormat,
+        timeZone,
         timeUnit,
         epoch,
         booleanStrings,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToTemporalCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToTemporalCodec.java
@@ -11,19 +11,18 @@ package com.datastax.dsbulk.engine.internal.codecs.json;
 import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
 
 import com.datastax.driver.core.TypeCodec;
-import com.datastax.dsbulk.engine.internal.codecs.util.CodecUtils;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import com.fasterxml.jackson.databind.JsonNode;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.List;
 
 public abstract class JsonNodeToTemporalCodec<T extends TemporalAccessor>
     extends JsonNodeConvertingCodec<T> {
 
-  final DateTimeFormatter temporalFormat;
+  final TemporalFormat temporalFormat;
 
   JsonNodeToTemporalCodec(
-      TypeCodec<T> targetCodec, DateTimeFormatter temporalFormat, List<String> nullStrings) {
+      TypeCodec<T> targetCodec, TemporalFormat temporalFormat, List<String> nullStrings) {
     super(targetCodec, nullStrings);
     this.temporalFormat = temporalFormat;
   }
@@ -38,6 +37,6 @@ public abstract class JsonNodeToTemporalCodec<T extends TemporalAccessor>
       return null;
     }
     String s = node.asText();
-    return CodecUtils.parseTemporal(s, temporalFormat);
+    return temporalFormat.parse(s);
   }
 }

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBigDecimalCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBigDecimalCodec.java
@@ -11,12 +11,13 @@ package com.datastax.dsbulk.engine.internal.codecs.string;
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.CodecUtils;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -27,7 +28,8 @@ public class StringToBigDecimalCodec extends StringToNumberCodec<BigDecimal> {
       FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
-      DateTimeFormatter temporalFormat,
+      TemporalFormat temporalFormat,
+      ZoneId timeZone,
       TimeUnit timeUnit,
       ZonedDateTime epoch,
       Map<String, Boolean> booleanStrings,
@@ -39,6 +41,7 @@ public class StringToBigDecimalCodec extends StringToNumberCodec<BigDecimal> {
         overflowStrategy,
         roundingMode,
         temporalFormat,
+        timeZone,
         timeUnit,
         epoch,
         booleanStrings,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBigIntegerCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBigIntegerCodec.java
@@ -12,13 +12,14 @@ import static java.util.stream.Collectors.toList;
 
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -29,7 +30,8 @@ public class StringToBigIntegerCodec extends StringToNumberCodec<BigInteger> {
       FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
-      DateTimeFormatter temporalFormat,
+      TemporalFormat temporalFormat,
+      ZoneId timeZone,
       TimeUnit timeUnit,
       ZonedDateTime epoch,
       Map<String, Boolean> booleanStrings,
@@ -41,6 +43,7 @@ public class StringToBigIntegerCodec extends StringToNumberCodec<BigInteger> {
         overflowStrategy,
         roundingMode,
         temporalFormat,
+        timeZone,
         timeUnit,
         epoch,
         booleanStrings,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToByteCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToByteCodec.java
@@ -12,12 +12,13 @@ import static java.util.stream.Collectors.toList;
 
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -28,7 +29,8 @@ public class StringToByteCodec extends StringToNumberCodec<Byte> {
       FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
-      DateTimeFormatter temporalFormat,
+      TemporalFormat temporalFormat,
+      ZoneId timeZone,
       TimeUnit timeUnit,
       ZonedDateTime epoch,
       Map<String, Boolean> booleanStrings,
@@ -40,6 +42,7 @@ public class StringToByteCodec extends StringToNumberCodec<Byte> {
         overflowStrategy,
         roundingMode,
         temporalFormat,
+        timeZone,
         timeUnit,
         epoch,
         booleanStrings,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToDoubleCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToDoubleCodec.java
@@ -12,12 +12,13 @@ import static java.util.stream.Collectors.toList;
 
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -28,7 +29,8 @@ public class StringToDoubleCodec extends StringToNumberCodec<Double> {
       FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
-      DateTimeFormatter temporalFormat,
+      TemporalFormat temporalFormat,
+      ZoneId timeZone,
       TimeUnit timeUnit,
       ZonedDateTime epoch,
       Map<String, Boolean> booleanStrings,
@@ -40,6 +42,7 @@ public class StringToDoubleCodec extends StringToNumberCodec<Double> {
         overflowStrategy,
         roundingMode,
         temporalFormat,
+        timeZone,
         timeUnit,
         epoch,
         booleanStrings,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToFloatCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToFloatCodec.java
@@ -12,12 +12,13 @@ import static java.util.stream.Collectors.toList;
 
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -28,7 +29,8 @@ public class StringToFloatCodec extends StringToNumberCodec<Float> {
       FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
-      DateTimeFormatter temporalFormat,
+      TemporalFormat temporalFormat,
+      ZoneId timeZone,
       TimeUnit timeUnit,
       ZonedDateTime epoch,
       Map<String, Boolean> booleanStrings,
@@ -40,6 +42,7 @@ public class StringToFloatCodec extends StringToNumberCodec<Float> {
         overflowStrategy,
         roundingMode,
         temporalFormat,
+        timeZone,
         timeUnit,
         epoch,
         booleanStrings,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToInstantCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToInstantCodec.java
@@ -10,11 +10,12 @@ package com.datastax.dsbulk.engine.internal.codecs.string;
 
 import com.datastax.driver.extras.codecs.jdk8.InstantCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.CodecUtils;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.text.NumberFormat;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -22,17 +23,20 @@ import java.util.concurrent.TimeUnit;
 public class StringToInstantCodec extends StringToTemporalCodec<Instant> {
 
   private final FastThreadLocal<NumberFormat> numberFormat;
+  private final ZoneId timeZone;
   private final TimeUnit timeUnit;
   private final ZonedDateTime epoch;
 
   public StringToInstantCodec(
-      DateTimeFormatter temporalFormat,
+      TemporalFormat temporalFormat,
       FastThreadLocal<NumberFormat> numberFormat,
+      ZoneId timeZone,
       TimeUnit timeUnit,
       ZonedDateTime epoch,
       List<String> nullStrings) {
     super(InstantCodec.instance, temporalFormat, nullStrings);
     this.numberFormat = numberFormat;
+    this.timeZone = timeZone;
     this.timeUnit = timeUnit;
     this.epoch = epoch;
   }
@@ -43,8 +47,7 @@ public class StringToInstantCodec extends StringToTemporalCodec<Instant> {
     if (temporal == null) {
       return null;
     }
-    return CodecUtils.convertTemporal(
-        temporal, Instant.class, temporalFormat.getZone(), epoch.toLocalDate());
+    return CodecUtils.convertTemporal(temporal, Instant.class, timeZone, epoch.toLocalDate());
   }
 
   @Override

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToIntegerCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToIntegerCodec.java
@@ -12,12 +12,13 @@ import static java.util.stream.Collectors.toList;
 
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -28,7 +29,8 @@ public class StringToIntegerCodec extends StringToNumberCodec<Integer> {
       FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
-      DateTimeFormatter temporalFormat,
+      TemporalFormat temporalFormat,
+      ZoneId timeZone,
       TimeUnit timeUnit,
       ZonedDateTime epoch,
       Map<String, Boolean> booleanStrings,
@@ -40,6 +42,7 @@ public class StringToIntegerCodec extends StringToNumberCodec<Integer> {
         overflowStrategy,
         roundingMode,
         temporalFormat,
+        timeZone,
         timeUnit,
         epoch,
         booleanStrings,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToLocalDateCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToLocalDateCodec.java
@@ -10,15 +10,19 @@ package com.datastax.dsbulk.engine.internal.codecs.string;
 
 import com.datastax.driver.extras.codecs.jdk8.LocalDateCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.CodecUtils;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
+import java.time.ZoneId;
 import java.time.temporal.TemporalAccessor;
 import java.util.List;
 
 public class StringToLocalDateCodec extends StringToTemporalCodec<LocalDate> {
 
-  public StringToLocalDateCodec(DateTimeFormatter parser, List<String> nullStrings) {
+  private final ZoneId timeZone;
+
+  public StringToLocalDateCodec(TemporalFormat parser, ZoneId timeZone, List<String> nullStrings) {
     super(LocalDateCodec.instance, parser, nullStrings);
+    this.timeZone = timeZone;
   }
 
   @Override
@@ -27,6 +31,6 @@ public class StringToLocalDateCodec extends StringToTemporalCodec<LocalDate> {
     if (temporal == null) {
       return null;
     }
-    return CodecUtils.toLocalDate(temporal, temporalFormat.getZone());
+    return CodecUtils.toLocalDate(temporal, timeZone);
   }
 }

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToLocalTimeCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToLocalTimeCodec.java
@@ -10,15 +10,19 @@ package com.datastax.dsbulk.engine.internal.codecs.string;
 
 import com.datastax.driver.extras.codecs.jdk8.LocalTimeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.CodecUtils;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
+import java.time.ZoneId;
 import java.time.temporal.TemporalAccessor;
 import java.util.List;
 
 public class StringToLocalTimeCodec extends StringToTemporalCodec<LocalTime> {
 
-  public StringToLocalTimeCodec(DateTimeFormatter parser, List<String> nullStrings) {
+  private final ZoneId timeZone;
+
+  public StringToLocalTimeCodec(TemporalFormat parser, ZoneId timeZone, List<String> nullStrings) {
     super(LocalTimeCodec.instance, parser, nullStrings);
+    this.timeZone = timeZone;
   }
 
   @Override
@@ -27,6 +31,6 @@ public class StringToLocalTimeCodec extends StringToTemporalCodec<LocalTime> {
     if (temporal == null) {
       return null;
     }
-    return CodecUtils.toLocalTime(temporal, temporalFormat.getZone());
+    return CodecUtils.toLocalTime(temporal, timeZone);
   }
 }

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToLongCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToLongCodec.java
@@ -12,12 +12,13 @@ import static java.util.stream.Collectors.toList;
 
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -28,7 +29,8 @@ public class StringToLongCodec extends StringToNumberCodec<Long> {
       FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
-      DateTimeFormatter temporalFormat,
+      TemporalFormat temporalFormat,
+      ZoneId timeZone,
       TimeUnit timeUnit,
       ZonedDateTime epoch,
       Map<String, Boolean> booleanStrings,
@@ -40,6 +42,7 @@ public class StringToLongCodec extends StringToNumberCodec<Long> {
         overflowStrategy,
         roundingMode,
         temporalFormat,
+        timeZone,
         timeUnit,
         epoch,
         booleanStrings,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToNumberCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToNumberCodec.java
@@ -11,11 +11,12 @@ package com.datastax.dsbulk.engine.internal.codecs.string;
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.util.CodecUtils;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -25,7 +26,8 @@ public abstract class StringToNumberCodec<N extends Number> extends StringConver
   private final FastThreadLocal<NumberFormat> numberFormat;
   private final OverflowStrategy overflowStrategy;
   private final RoundingMode roundingMode;
-  private final DateTimeFormatter temporalFormat;
+  private final TemporalFormat temporalFormat;
+  private final ZoneId timeZone;
   private final TimeUnit timeUnit;
   private final ZonedDateTime epoch;
   private final Map<String, Boolean> booleanStrings;
@@ -36,7 +38,8 @@ public abstract class StringToNumberCodec<N extends Number> extends StringConver
       FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
-      DateTimeFormatter temporalFormat,
+      TemporalFormat temporalFormat,
+      ZoneId timeZone,
       TimeUnit timeUnit,
       ZonedDateTime epoch,
       Map<String, Boolean> booleanStrings,
@@ -47,6 +50,7 @@ public abstract class StringToNumberCodec<N extends Number> extends StringConver
     this.overflowStrategy = overflowStrategy;
     this.roundingMode = roundingMode;
     this.temporalFormat = temporalFormat;
+    this.timeZone = timeZone;
     this.timeUnit = timeUnit;
     this.epoch = epoch;
     this.booleanStrings = booleanStrings;
@@ -66,7 +70,14 @@ public abstract class StringToNumberCodec<N extends Number> extends StringConver
       return null;
     }
     return CodecUtils.parseNumber(
-        s, numberFormat.get(), temporalFormat, timeUnit, epoch, booleanStrings, booleanNumbers);
+        s,
+        numberFormat.get(),
+        temporalFormat,
+        timeZone,
+        timeUnit,
+        epoch,
+        booleanStrings,
+        booleanNumbers);
   }
 
   N narrowNumber(Number number, Class<? extends N> targetClass) {

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToShortCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToShortCodec.java
@@ -11,12 +11,13 @@ package com.datastax.dsbulk.engine.internal.codecs.string;
 import static java.util.stream.Collectors.toList;
 
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -27,7 +28,8 @@ public class StringToShortCodec extends StringToNumberCodec<Short> {
       FastThreadLocal<NumberFormat> numberFormat,
       OverflowStrategy overflowStrategy,
       RoundingMode roundingMode,
-      DateTimeFormatter temporalFormat,
+      TemporalFormat temporalFormat,
+      ZoneId timeZone,
       TimeUnit timeUnit,
       ZonedDateTime epoch,
       Map<String, Boolean> booleanStrings,
@@ -39,6 +41,7 @@ public class StringToShortCodec extends StringToNumberCodec<Short> {
         overflowStrategy,
         roundingMode,
         temporalFormat,
+        timeZone,
         timeUnit,
         epoch,
         booleanStrings,

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToTemporalCodec.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToTemporalCodec.java
@@ -9,18 +9,17 @@
 package com.datastax.dsbulk.engine.internal.codecs.string;
 
 import com.datastax.driver.core.TypeCodec;
-import com.datastax.dsbulk.engine.internal.codecs.util.CodecUtils;
-import java.time.format.DateTimeFormatter;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import java.time.temporal.TemporalAccessor;
 import java.util.List;
 
 public abstract class StringToTemporalCodec<T extends TemporalAccessor>
     extends StringConvertingCodec<T> {
 
-  final DateTimeFormatter temporalFormat;
+  final TemporalFormat temporalFormat;
 
   StringToTemporalCodec(
-      TypeCodec<T> targetCodec, DateTimeFormatter temporalFormat, List<String> nullStrings) {
+      TypeCodec<T> targetCodec, TemporalFormat temporalFormat, List<String> nullStrings) {
     super(targetCodec, nullStrings);
     this.temporalFormat = temporalFormat;
   }
@@ -37,6 +36,6 @@ public abstract class StringToTemporalCodec<T extends TemporalAccessor>
     if (isNull(s)) {
       return null;
     }
-    return CodecUtils.parseTemporal(s, temporalFormat);
+    return temporalFormat.parse(s);
   }
 }

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/util/CqlTemporalFormat.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/util/CqlTemporalFormat.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.util;
+
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+import static java.util.Locale.US;
+
+import java.time.ZoneId;
+import java.time.chrono.IsoChronology;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.ResolverStyle;
+import java.util.Locale;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A special zoned temporal format that recognizes all valid CQL input formats when parsing.
+ *
+ * <p>When formatting, this format uses "uuuu-MM-dd HH:mm:ss.SSS zzz" as the formatting pattern,
+ * thus producing output such as "2017-11-23 14:24:59.999 UTC".
+ */
+public class CqlTemporalFormat extends ZonedTemporalFormat {
+
+  public static final CqlTemporalFormat DEFAULT_INSTANCE =
+      new CqlTemporalFormat(ZoneId.of("UTC"), US);
+
+  public CqlTemporalFormat(ZoneId timeZone, Locale locale) {
+    super(createParser(locale), createFormatter(timeZone, locale), timeZone);
+  }
+
+  @NotNull
+  private static DateTimeFormatter createParser(Locale locale) {
+    // this formatter is a hybrid parser that combines all valid CQL patterns declared in C* 2.2+
+    // into a single parser. To achieve that we "cheat" a little bit and accept many optional
+    // components
+    // that would not make sense together. For example, we accept both 'T' and blank as date-time
+    // separators,
+    // so in theory we also accept "T " (i.e. 'T' followed by a blank).
+    return new DateTimeFormatterBuilder()
+        .parseStrict()
+        .parseCaseInsensitive()
+
+        // date part
+        .optionalStart()
+        .append(DateTimeFormatter.ISO_LOCAL_DATE)
+        .optionalEnd()
+
+        // date-time separators
+        .optionalStart()
+        .appendLiteral('T')
+        .optionalEnd()
+        .optionalStart()
+        .appendLiteral(' ')
+        .optionalEnd()
+
+        // time part, includes fraction of second
+        .optionalStart()
+        .append(DateTimeFormatter.ISO_LOCAL_TIME)
+        .optionalEnd()
+
+        // time zone separator
+        .optionalStart()
+        .appendLiteral(' ')
+        .optionalEnd()
+
+        // time zone part
+        .optionalStart()
+        .appendPattern("XXX")
+        .optionalEnd()
+        .optionalStart()
+        .appendPattern("zzz")
+        .optionalEnd()
+        .optionalStart()
+        .appendPattern("XX")
+        .optionalEnd()
+        .optionalStart()
+        .appendPattern("zz")
+        .optionalEnd()
+        .optionalStart()
+        .appendPattern("X")
+        .optionalEnd()
+        .optionalStart()
+        .appendPattern("z")
+        .optionalEnd()
+
+        // add defaults for missing fields, which allows the parsing to be lenient when
+        // some fields cannot be inferred from the input.
+        .parseDefaulting(HOUR_OF_DAY, 0)
+        .parseDefaulting(MINUTE_OF_HOUR, 0)
+        .parseDefaulting(SECOND_OF_MINUTE, 0)
+        .parseDefaulting(NANO_OF_SECOND, 0)
+        .toFormatter(locale)
+        .withResolverStyle(ResolverStyle.STRICT)
+        .withChronology(IsoChronology.INSTANCE);
+  }
+
+  @NotNull
+  private static DateTimeFormatter createFormatter(ZoneId timeZone, Locale locale) {
+    return DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss.SSS zzz", locale)
+        .withResolverStyle(ResolverStyle.STRICT)
+        .withChronology(IsoChronology.INSTANCE)
+        .withZone(timeZone);
+  }
+}

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/util/SimpleTemporalFormat.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/util/SimpleTemporalFormat.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.util;
+
+import java.text.ParsePosition;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAccessor;
+import java.util.Objects;
+
+/**
+ * A generic temporal format. For zoned temporals, it is often preferable to use {@link
+ * ZonedTemporalFormat} instead.
+ */
+public class SimpleTemporalFormat implements TemporalFormat {
+
+  private final DateTimeFormatter parser;
+  private final DateTimeFormatter formatter;
+
+  public SimpleTemporalFormat(DateTimeFormatter parserAndFormatter) {
+    this(parserAndFormatter, parserAndFormatter);
+  }
+
+  public SimpleTemporalFormat(DateTimeFormatter parser, DateTimeFormatter formatter) {
+    this.parser = Objects.requireNonNull(parser, "parser cannot be null");
+    this.formatter = Objects.requireNonNull(formatter, "formatter cannot be null");
+  }
+
+  @Override
+  public TemporalAccessor parse(String text) {
+    if (text == null) {
+      return null;
+    }
+    if (text.isEmpty()) {
+      throw new DateTimeParseException("Cannot convert empty string to temporal", text, 0);
+    }
+    ParsePosition pos = new ParsePosition(0);
+    TemporalAccessor temporal = parser.parse(text.trim(), pos);
+    if (pos.getIndex() != text.length()) {
+      throw new DateTimeParseException(
+          String.format("Could not parse temporal at index %d: %s", pos.getIndex(), text),
+          text,
+          pos.getIndex());
+    }
+    return temporal;
+  }
+
+  @Override
+  public String format(TemporalAccessor temporal) {
+    if (temporal == null) {
+      return null;
+    }
+    return formatter.format(temporal);
+  }
+}

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/util/TemporalFormat.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/util/TemporalFormat.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.util;
+
+import java.time.DateTimeException;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAccessor;
+
+/**
+ * A small wrapper around {@link java.time.format.DateTimeFormatter} that allows to use different
+ * formats when parsing and formatting.
+ */
+public interface TemporalFormat {
+
+  /**
+   * Parses the given string as a temporal.
+   *
+   * @param text the string to parse, may be {@code null}.
+   * @return a {@link TemporalAccessor} or {@code null} if the string was {@code null} or empty.
+   * @throws DateTimeParseException if the string cannot be parsed.
+   */
+  TemporalAccessor parse(String text) throws DateTimeParseException;
+
+  /**
+   * Formats the given temporal.
+   *
+   * @param temporal the value to format.
+   * @return the formatted value or {@code null} if the value was {@code null}.
+   * @throws DateTimeException if the value cannot be formatted.
+   */
+  String format(TemporalAccessor temporal) throws DateTimeException;
+}

--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/util/ZonedTemporalFormat.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/codecs/util/ZonedTemporalFormat.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.util;
+
+import com.google.common.base.Preconditions;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalQueries;
+
+/**
+ * A special temporal format that applies a fixed time zone to parsed inputs when they do not
+ * contain any time zone or time offset information, thus allowing such inputs to be converted to an
+ * {@link Instant}.
+ */
+public class ZonedTemporalFormat extends SimpleTemporalFormat {
+
+  private final ZoneId timeZone;
+
+  public ZonedTemporalFormat(DateTimeFormatter parserAndFormatter, ZoneId timeZone) {
+    this(parserAndFormatter, parserAndFormatter, timeZone);
+  }
+
+  public ZonedTemporalFormat(
+      DateTimeFormatter parser, DateTimeFormatter formatter, ZoneId timeZone) {
+    // Always force a time zone when formatting (makes formatting of unzoned input possible),
+    // but never set a time zone when parsing (dangerous as original zone info could be overridden
+    // and data altered)
+    super(parser, formatter.withZone(timeZone));
+    Preconditions.checkState(parser.getZone() == null, "parser should not have an override zone");
+    this.timeZone = timeZone;
+  }
+
+  @Override
+  public TemporalAccessor parse(String text) {
+    TemporalAccessor temporal = super.parse(text);
+    if (temporal == null) {
+      return null;
+    }
+    // If an instant cannot be inferred from the input (possibly because the input did not
+    // contain any time zone information), try extracting the local date/time from the input and
+    // apply the default time zone.
+    if (!temporal.isSupported(ChronoField.INSTANT_SECONDS)) {
+      return ZonedDateTime.of(
+          temporal.query(TemporalQueries.localDate()),
+          temporal.query(TemporalQueries.localTime()),
+          timeZone);
+    } else {
+      return temporal;
+    }
+  }
+}

--- a/engine/src/main/resources/reference.conf
+++ b/engine/src/main/resources/reference.conf
@@ -406,7 +406,7 @@ dsbulk {
 
     # The temporal pattern to use for `String` to CQL timestamp conversions. Valid choices:
     #
-    # - A date-time pattern such as `uuuu-MM-dd HH:mm:ss`.
+    # - A date-time pattern such as `yyyy-MM-dd HH:mm:ss`.
     # - A pre-defined formatter such as `ISO_ZONED_DATE_TIME` or `ISO_INSTANT`. Any public static field in `java.time.format.DateTimeFormatter` can be used.
     # - The special value `CQL_DATE_TIME`, which is a special parser that accepts most CQL date, time and timestamp literals (see below).
     #
@@ -414,40 +414,12 @@ dsbulk {
     #
     # For more information about CQL date, time and timestamp literals, see [Date, time, and timestamp format](https://docs.datastax.com/en/dse/5.1/cql/cql/cql_reference/refDateTimeFormats.html?hl=timestamp).
     #
-    # The default value is the special `CQL_DATE_TIME` value. This format is roughly equivalent to the pre-defined `ISO_ZONED_DATE_TIME`, but is more permissive regarding missing fields and time zone formats.
-    #
-    # When parsing, this format recognizes most CQL temporal literals, e.g.:
-    #
-    # - Local dates:
-    #     - `2012-01-01`
-    # - Local times:
-    #     - `12:34`
-    #     - `12:34:56`
-    #     - `12:34:56.123`
-    #     - `12:34:56.123456`
-    #     - `12:34:56.123456789`
-    # - Local date-times:
-    #     - `2012-01-01T12:34`
-    #     - `2012-01-01T12:34:56`
-    #     - `2012-01-01T12:34:56.123`
-    #     - `2012-01-01T12:34:56.123456`
-    #     - `2012-01-01T12:34:56.123456789`
-    # - Zoned date-times:
-    #     - `2012-01-01T12:34+01:00`
-    #     - `2012-01-01T12:34:56+01:00`
-    #     - `2012-01-01T12:34:56.123+01:00`
-    #     - `2012-01-01T12:34:56.123456+01:00`
-    #     - `2012-01-01T12:34:56.123456789+01:00`
-    #     - `2012-01-01T12:34:56.123456789+01:00[Europe/Paris]`
-    #
-    # When the input is a local date, the timestamp is resolved using the time zone specified under `timeZone`, at midnight. When the input is a local time, the timestamp is resolved using the time zone specified under `timeZone`, and the date is inferred from the instant specified under `epoch` (by default, January 1st 1970).
-    #
-    # When formatting, this format is equivalent to `ISO_ZONED_DATE_TIME`, and produces formatted output of the following form: '2011-12-03T10:15:30.567+01:00[Europe/Paris]'.
+    # The default value is the special `CQL_DATE_TIME` value. When parsing, this format recognizes all CQL temporal literals; if the input is a local date, the timestamp is resolved using the time zone specified under `timeZone`, at midnight. When formatting, this format produces formatted output of the following form: '2011-12-03 10:15:30.567 CEST'.
     timestamp = "CQL_DATE_TIME"
 
     # The temporal pattern to use for `String` to CQL date conversions. Valid choices:
     #
-    # - A date-time pattern such as `uuuu-MM-dd`.
+    # - A date-time pattern such as `yyyy-MM-dd`.
     # - A pre-defined formatter such as `ISO_LOCAL_DATE`. Any public static field in `java.time.format.DateTimeFormatter` can be used.
     #
     # For more information on patterns and pre-defined formatters, see [https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns).

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBigDecimalCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBigDecimalCodecTest.java
@@ -8,7 +8,6 @@
  */
 package com.datastax.dsbulk.engine.internal.codecs.json;
 
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
@@ -20,6 +19,7 @@ import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.US;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.google.common.collect.ImmutableMap;
@@ -39,7 +39,8 @@ class JsonNodeToBigDecimalCodecTest {
           numberFormat,
           OverflowStrategy.REJECT,
           RoundingMode.HALF_EVEN,
-          CQL_DATE_TIME_FORMAT,
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          UTC,
           MILLISECONDS,
           EPOCH.atZone(UTC),
           ImmutableMap.of("true", true, "false", false),

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBigIntegerCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToBigIntegerCodecTest.java
@@ -8,7 +8,6 @@
  */
 package com.datastax.dsbulk.engine.internal.codecs.json;
 
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
@@ -20,6 +19,7 @@ import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.US;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.google.common.collect.ImmutableMap;
@@ -39,7 +39,8 @@ class JsonNodeToBigIntegerCodecTest {
           numberFormat,
           OverflowStrategy.REJECT,
           RoundingMode.HALF_EVEN,
-          CQL_DATE_TIME_FORMAT,
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          UTC,
           MILLISECONDS,
           EPOCH.atZone(UTC),
           ImmutableMap.of("true", true, "false", false),

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToByteCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToByteCodecTest.java
@@ -8,7 +8,6 @@
  */
 package com.datastax.dsbulk.engine.internal.codecs.json;
 
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
@@ -20,6 +19,7 @@ import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.US;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.google.common.collect.ImmutableMap;
@@ -37,7 +37,8 @@ class JsonNodeToByteCodecTest {
           numberFormat,
           OverflowStrategy.REJECT,
           HALF_EVEN,
-          CQL_DATE_TIME_FORMAT,
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          UTC,
           MILLISECONDS,
           EPOCH.atZone(UTC),
           ImmutableMap.of("true", true, "false", false),

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToDoubleCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToDoubleCodecTest.java
@@ -8,7 +8,6 @@
  */
 package com.datastax.dsbulk.engine.internal.codecs.json;
 
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
@@ -20,6 +19,7 @@ import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.US;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.google.common.collect.ImmutableMap;
@@ -38,7 +38,8 @@ class JsonNodeToDoubleCodecTest {
           numberFormat,
           OverflowStrategy.REJECT,
           RoundingMode.HALF_EVEN,
-          CQL_DATE_TIME_FORMAT,
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          UTC,
           MILLISECONDS,
           EPOCH.atZone(UTC),
           ImmutableMap.of("true", true, "false", false),

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToFloatCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToFloatCodecTest.java
@@ -8,7 +8,6 @@
  */
 package com.datastax.dsbulk.engine.internal.codecs.json;
 
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
@@ -20,6 +19,7 @@ import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.US;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.google.common.collect.ImmutableMap;
@@ -38,7 +38,8 @@ class JsonNodeToFloatCodecTest {
           numberFormat,
           OverflowStrategy.REJECT,
           RoundingMode.HALF_EVEN,
-          CQL_DATE_TIME_FORMAT,
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          UTC,
           MILLISECONDS,
           EPOCH.atZone(UTC),
           ImmutableMap.of("true", true, "false", false),

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToIntegerCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToIntegerCodecTest.java
@@ -8,7 +8,6 @@
  */
 package com.datastax.dsbulk.engine.internal.codecs.json;
 
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
@@ -20,6 +19,7 @@ import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.US;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.google.common.collect.ImmutableMap;
@@ -38,7 +38,8 @@ class JsonNodeToIntegerCodecTest {
           numberFormat,
           OverflowStrategy.REJECT,
           RoundingMode.HALF_EVEN,
-          CQL_DATE_TIME_FORMAT,
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          UTC,
           MILLISECONDS,
           EPOCH.atZone(UTC),
           ImmutableMap.of("true", true, "false", false),

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToListCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToListCodecTest.java
@@ -11,7 +11,6 @@ package com.datastax.dsbulk.engine.internal.codecs.json;
 import static com.datastax.driver.core.TypeCodec.cdouble;
 import static com.datastax.driver.core.TypeCodec.list;
 import static com.datastax.driver.core.TypeCodec.varchar;
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
@@ -24,6 +23,7 @@ import static java.util.Locale.US;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import com.datastax.driver.core.TypeCodec;
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -48,7 +48,8 @@ class JsonNodeToListCodecTest {
           numberFormat,
           OverflowStrategy.REJECT,
           RoundingMode.HALF_EVEN,
-          CQL_DATE_TIME_FORMAT,
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          UTC,
           MILLISECONDS,
           EPOCH.atZone(UTC),
           ImmutableMap.of("true", true, "false", false),

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToLocalDateCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToLocalDateCodecTest.java
@@ -11,23 +11,19 @@ package com.datastax.dsbulk.engine.internal.codecs.json;
 import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
-import static java.time.Instant.EPOCH;
-import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.US;
 
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class JsonNodeToLocalDateCodecTest {
 
-  private DateTimeFormatter format1 =
-      CodecSettings.getDateTimeFormat("ISO_LOCAL_DATE", UTC, US, EPOCH.atZone(UTC));
+  private TemporalFormat format1 = CodecSettings.getTemporalFormat("ISO_LOCAL_DATE", null, US);
 
-  private DateTimeFormatter format2 =
-      CodecSettings.getDateTimeFormat("yyyyMMdd", UTC, US, EPOCH.atZone(UTC));
+  private TemporalFormat format2 = CodecSettings.getTemporalFormat("yyyyMMdd", null, US);
 
   private final List<String> nullStrings = newArrayList("NULL");
 

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToLocalTimeCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToLocalTimeCodecTest.java
@@ -11,24 +11,21 @@ package com.datastax.dsbulk.engine.internal.codecs.json;
 import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
-import static java.time.Instant.EPOCH;
-import static java.time.ZoneOffset.UTC;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static java.util.Locale.US;
 
+import com.datastax.dsbulk.engine.internal.codecs.util.SimpleTemporalFormat;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class JsonNodeToLocalTimeCodecTest {
 
-  private DateTimeFormatter format1 =
-      CodecSettings.getDateTimeFormat("ISO_LOCAL_TIME", UTC, US, EPOCH.atZone(UTC));
+  private TemporalFormat format1 = CodecSettings.getTemporalFormat("ISO_LOCAL_TIME", null, US);
 
-  private DateTimeFormatter format2 =
-      CodecSettings.getDateTimeFormat("HHmmss.SSS", UTC, US, EPOCH.atZone(UTC));
+  private TemporalFormat format2 = CodecSettings.getTemporalFormat("HHmmss.SSS", null, US);
 
   private final List<String> nullStrings = newArrayList("NULL");
 
@@ -72,7 +69,8 @@ class JsonNodeToLocalTimeCodecTest {
 
   @Test
   void should_not_convert_from_invalid_external() {
-    JsonNodeToLocalTimeCodec codec = new JsonNodeToLocalTimeCodec(ISO_LOCAL_DATE, nullStrings);
+    JsonNodeToLocalTimeCodec codec =
+        new JsonNodeToLocalTimeCodec(new SimpleTemporalFormat(ISO_LOCAL_DATE), nullStrings);
     assertThat(codec)
         .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode(""))
         .cannotConvertFromExternal(JSON_NODE_FACTORY.textNode("not a valid date format"));

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToLongCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToLongCodecTest.java
@@ -8,7 +8,6 @@
  */
 package com.datastax.dsbulk.engine.internal.codecs.json;
 
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
@@ -20,6 +19,7 @@ import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.US;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.google.common.collect.ImmutableMap;
@@ -38,7 +38,8 @@ class JsonNodeToLongCodecTest {
           numberFormat,
           OverflowStrategy.REJECT,
           RoundingMode.HALF_EVEN,
-          CQL_DATE_TIME_FORMAT,
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          UTC,
           MILLISECONDS,
           EPOCH.atZone(UTC),
           ImmutableMap.of("true", true, "false", false),

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToMapCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToMapCodecTest.java
@@ -8,7 +8,6 @@
  */
 package com.datastax.dsbulk.engine.internal.codecs.json;
 
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
@@ -23,6 +22,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.ConvertingCodec;
 import com.datastax.dsbulk.engine.internal.codecs.string.StringToDoubleCodec;
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -50,7 +50,8 @@ class JsonNodeToMapCodecTest {
           numberFormat,
           OverflowStrategy.REJECT,
           RoundingMode.HALF_EVEN,
-          CQL_DATE_TIME_FORMAT,
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          UTC,
           MILLISECONDS,
           EPOCH.atZone(UTC),
           ImmutableMap.of("true", true, "false", false),

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToSetCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToSetCodecTest.java
@@ -11,7 +11,6 @@ package com.datastax.dsbulk.engine.internal.codecs.json;
 import static com.datastax.driver.core.TypeCodec.cdouble;
 import static com.datastax.driver.core.TypeCodec.set;
 import static com.datastax.driver.core.TypeCodec.varchar;
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
@@ -25,6 +24,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 
 import com.datastax.driver.core.TypeCodec;
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -50,7 +50,8 @@ class JsonNodeToSetCodecTest {
           numberFormat,
           OverflowStrategy.REJECT,
           RoundingMode.HALF_EVEN,
-          CQL_DATE_TIME_FORMAT,
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          UTC,
           MILLISECONDS,
           EPOCH.atZone(UTC),
           ImmutableMap.of("true", true, "false", false),

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToShortCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToShortCodecTest.java
@@ -8,7 +8,6 @@
  */
 package com.datastax.dsbulk.engine.internal.codecs.json;
 
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
@@ -20,6 +19,7 @@ import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.US;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.google.common.collect.ImmutableMap;
@@ -38,7 +38,8 @@ class JsonNodeToShortCodecTest {
           numberFormat,
           OverflowStrategy.REJECT,
           RoundingMode.HALF_EVEN,
-          CQL_DATE_TIME_FORMAT,
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          UTC,
           MILLISECONDS,
           EPOCH.atZone(UTC),
           ImmutableMap.of("true", true, "false", false),

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToTupleCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToTupleCodecTest.java
@@ -12,7 +12,6 @@ import static com.datastax.driver.core.DataType.timestamp;
 import static com.datastax.driver.core.DataType.varchar;
 import static com.datastax.driver.core.DriverCoreEngineTestHooks.newTupleType;
 import static com.datastax.driver.core.ProtocolVersion.V4;
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
@@ -27,6 +26,7 @@ import com.datastax.driver.core.TupleType;
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.driver.extras.codecs.jdk8.InstantCodec;
 import com.datastax.dsbulk.engine.internal.codecs.ConvertingCodec;
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -52,7 +52,12 @@ class JsonNodeToTupleCodecTest {
 
   private final ConvertingCodec eltCodec1 =
       new JsonNodeToInstantCodec(
-          CQL_DATE_TIME_FORMAT, numberFormat, MILLISECONDS, EPOCH.atZone(UTC), nullStrings);
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          numberFormat,
+          UTC,
+          MILLISECONDS,
+          EPOCH.atZone(UTC),
+          nullStrings);
 
   private final ConvertingCodec eltCodec2 =
       new JsonNodeToStringCodec(TypeCodec.varchar(), objectMapper, nullStrings);
@@ -96,7 +101,7 @@ class JsonNodeToTupleCodecTest {
     assertThat(codec)
         .convertsFromInternal(
             tupleType.newValue(Instant.parse("2016-07-24T20:34:12.999Z"), "+01:00"))
-        .toExternal(objectMapper.readTree("[\"2016-07-24T20:34:12.999Z\",\"+01:00\"]"))
+        .toExternal(objectMapper.readTree("[\"2016-07-24 20:34:12.999 UTC\",\"+01:00\"]"))
         .convertsFromInternal(tupleType.newValue(null, null))
         .toExternal(objectMapper.readTree("[null,null]"))
         .convertsFromInternal(null)

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToUDTCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToUDTCodecTest.java
@@ -17,7 +17,6 @@ import static com.datastax.driver.core.DataType.varchar;
 import static com.datastax.driver.core.DriverCoreEngineTestHooks.newField;
 import static com.datastax.driver.core.DriverCoreEngineTestHooks.newUserType;
 import static com.datastax.driver.core.TypeCodec.userType;
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
@@ -36,6 +35,7 @@ import com.datastax.driver.core.UserType;
 import com.datastax.driver.extras.codecs.jdk8.LocalDateCodec;
 import com.datastax.dsbulk.engine.internal.codecs.ConvertingCodec;
 import com.datastax.dsbulk.engine.internal.codecs.string.StringToStringCodec;
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -76,7 +76,8 @@ class JsonNodeToUDTCodecTest {
           numberFormat,
           OverflowStrategy.REJECT,
           RoundingMode.HALF_EVEN,
-          CQL_DATE_TIME_FORMAT,
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          UTC,
           MILLISECONDS,
           EPOCH.atZone(UTC),
           ImmutableMap.of("true", true, "false", false),
@@ -90,7 +91,8 @@ class JsonNodeToUDTCodecTest {
               numberFormat,
               OverflowStrategy.REJECT,
               RoundingMode.HALF_EVEN,
-              CQL_DATE_TIME_FORMAT,
+              CqlTemporalFormat.DEFAULT_INSTANCE,
+              UTC,
               MILLISECONDS,
               EPOCH.atZone(UTC),
               ImmutableMap.of("true", true, "false", false),
@@ -129,7 +131,7 @@ class JsonNodeToUDTCodecTest {
   private final ConvertingCodec f2bCodec =
       new JsonNodeToListCodec<>(
           TypeCodec.list(LocalDateCodec.instance),
-          new JsonNodeToLocalDateCodec(CQL_DATE_TIME_FORMAT, nullStrings),
+          new JsonNodeToLocalDateCodec(CqlTemporalFormat.DEFAULT_INSTANCE, nullStrings),
           objectMapper,
           nullStrings);
 

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToUUIDCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/json/JsonNodeToUUIDCodecTest.java
@@ -12,7 +12,6 @@ import static com.datastax.dsbulk.engine.internal.codecs.util.TimeUUIDGenerator.
 import static com.datastax.dsbulk.engine.internal.codecs.util.TimeUUIDGenerator.MAX;
 import static com.datastax.dsbulk.engine.internal.codecs.util.TimeUUIDGenerator.MIN;
 import static com.datastax.dsbulk.engine.internal.codecs.util.TimeUUIDGenerator.RANDOM;
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.JSON_NODE_FACTORY;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
@@ -43,7 +42,12 @@ class JsonNodeToUUIDCodecTest {
 
   private StringToInstantCodec instantCodec =
       new StringToInstantCodec(
-          CQL_DATE_TIME_FORMAT, numberFormat, MILLISECONDS, EPOCH.atZone(UTC), nullStrings);
+          CodecSettings.getTemporalFormat("yyyy-MM-dd'T'HH:mm:ss[.SSSSSSSSS]XXX", UTC, US),
+          numberFormat,
+          UTC,
+          MILLISECONDS,
+          EPOCH.atZone(UTC),
+          nullStrings);
 
   private final JsonNodeToUUIDCodec codec =
       new JsonNodeToUUIDCodec(TypeCodec.uuid(), instantCodec, MIN, nullStrings);

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBigDecimalCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBigDecimalCodecTest.java
@@ -8,7 +8,6 @@
  */
 package com.datastax.dsbulk.engine.internal.codecs.string;
 
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.math.BigDecimal.ONE;
@@ -19,6 +18,7 @@ import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.US;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.google.common.collect.ImmutableMap;
@@ -38,7 +38,8 @@ class StringToBigDecimalCodecTest {
           numberFormat,
           OverflowStrategy.REJECT,
           RoundingMode.HALF_EVEN,
-          CQL_DATE_TIME_FORMAT,
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          UTC,
           MILLISECONDS,
           EPOCH.atZone(UTC),
           ImmutableMap.of("true", true, "false", false),

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBigIntegerCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToBigIntegerCodecTest.java
@@ -8,7 +8,6 @@
  */
 package com.datastax.dsbulk.engine.internal.codecs.string;
 
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.math.BigDecimal.ONE;
@@ -19,6 +18,7 @@ import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.US;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.google.common.collect.ImmutableMap;
@@ -26,7 +26,6 @@ import io.netty.util.concurrent.FastThreadLocal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class StringToBigIntegerCodecTest {
@@ -34,14 +33,13 @@ class StringToBigIntegerCodecTest {
   private final FastThreadLocal<NumberFormat> numberFormat =
       CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
 
-  private final List<String> nullStrings = newArrayList("NULL");
-
   private final StringToBigIntegerCodec codec =
       new StringToBigIntegerCodec(
           numberFormat,
           OverflowStrategy.REJECT,
           RoundingMode.HALF_EVEN,
-          CQL_DATE_TIME_FORMAT,
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          UTC,
           MILLISECONDS,
           EPOCH.atZone(UTC),
           ImmutableMap.of("true", true, "false", false),

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToByteCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToByteCodecTest.java
@@ -8,7 +8,6 @@
  */
 package com.datastax.dsbulk.engine.internal.codecs.string;
 
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.math.BigDecimal.ONE;
@@ -19,6 +18,7 @@ import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.US;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.google.common.collect.ImmutableMap;
@@ -37,7 +37,8 @@ class StringToByteCodecTest {
           numberFormat,
           OverflowStrategy.REJECT,
           RoundingMode.HALF_EVEN,
-          CQL_DATE_TIME_FORMAT,
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          UTC,
           MILLISECONDS,
           EPOCH.atZone(UTC),
           ImmutableMap.of("true", true, "false", false),

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToDoubleCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToDoubleCodecTest.java
@@ -8,7 +8,6 @@
  */
 package com.datastax.dsbulk.engine.internal.codecs.string;
 
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.math.BigDecimal.ONE;
@@ -19,6 +18,7 @@ import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.US;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.google.common.collect.ImmutableMap;
@@ -37,7 +37,8 @@ class StringToDoubleCodecTest {
           numberFormat,
           OverflowStrategy.REJECT,
           RoundingMode.HALF_EVEN,
-          CQL_DATE_TIME_FORMAT,
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          UTC,
           MILLISECONDS,
           EPOCH.atZone(UTC),
           ImmutableMap.of("true", true, "false", false),

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToFloatCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToFloatCodecTest.java
@@ -8,7 +8,6 @@
  */
 package com.datastax.dsbulk.engine.internal.codecs.string;
 
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.math.BigDecimal.ONE;
@@ -19,6 +18,7 @@ import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.US;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.google.common.collect.ImmutableMap;
@@ -37,7 +37,8 @@ class StringToFloatCodecTest {
           numberFormat,
           OverflowStrategy.REJECT,
           RoundingMode.HALF_EVEN,
-          CQL_DATE_TIME_FORMAT,
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          UTC,
           MILLISECONDS,
           EPOCH.atZone(UTC),
           ImmutableMap.of("true", true, "false", false),

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToInstantCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToInstantCodecTest.java
@@ -17,12 +17,13 @@ import static java.util.Locale.US;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.text.NumberFormat;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.format.DateTimeFormatter;
+import java.time.ZoneId;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -32,11 +33,11 @@ class StringToInstantCodecTest {
 
   private final Instant minutesAfterMillennium = millennium.plus(Duration.ofMinutes(123456));
 
-  private final DateTimeFormatter temporalFormat1 =
-      CodecSettings.getDateTimeFormat("CQL_DATE_TIME", UTC, US, EPOCH.atZone(UTC));
+  private final TemporalFormat temporalFormat1 =
+      CodecSettings.getTemporalFormat("CQL_DATE_TIME", ZoneId.of("UTC"), US);
 
-  private final DateTimeFormatter temporalFormat2 =
-      CodecSettings.getDateTimeFormat("yyyyMMddHHmmss", UTC, US, EPOCH.atZone(UTC));
+  private final TemporalFormat temporalFormat2 =
+      CodecSettings.getTemporalFormat("yyyyMMddHHmmss", ZoneId.of("UTC"), US);
 
   private final FastThreadLocal<NumberFormat> numberFormat =
       CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
@@ -47,7 +48,7 @@ class StringToInstantCodecTest {
   void should_convert_from_valid_external() {
     StringToInstantCodec codec =
         new StringToInstantCodec(
-            temporalFormat1, numberFormat, MILLISECONDS, EPOCH.atZone(UTC), nullStrings);
+            temporalFormat1, numberFormat, UTC, MILLISECONDS, EPOCH.atZone(UTC), nullStrings);
     assertThat(codec)
         .convertsFromExternal("2016-07-24T20:34")
         .toInternal(Instant.parse("2016-07-24T20:34:00Z"))
@@ -65,13 +66,13 @@ class StringToInstantCodecTest {
         .toInternal(null);
     codec =
         new StringToInstantCodec(
-            temporalFormat2, numberFormat, MILLISECONDS, EPOCH.atZone(UTC), nullStrings);
+            temporalFormat2, numberFormat, UTC, MILLISECONDS, EPOCH.atZone(UTC), nullStrings);
     assertThat(codec)
         .convertsFromExternal("20160724203412")
         .toInternal(Instant.parse("2016-07-24T20:34:12Z"));
     codec =
         new StringToInstantCodec(
-            temporalFormat1, numberFormat, MINUTES, millennium.atZone(UTC), nullStrings);
+            temporalFormat1, numberFormat, UTC, MINUTES, millennium.atZone(UTC), nullStrings);
     assertThat(codec)
         .convertsFromExternal("123456")
         .toInternal(minutesAfterMillennium)
@@ -83,27 +84,27 @@ class StringToInstantCodecTest {
   void should_convert_from_valid_internal() {
     StringToInstantCodec codec =
         new StringToInstantCodec(
-            temporalFormat1, numberFormat, MILLISECONDS, EPOCH.atZone(UTC), nullStrings);
+            temporalFormat1, numberFormat, UTC, MILLISECONDS, EPOCH.atZone(UTC), nullStrings);
     assertThat(codec)
         .convertsFromInternal(Instant.parse("2016-07-24T20:34:00Z"))
-        .toExternal("2016-07-24T20:34:00Z")
+        .toExternal("2016-07-24 20:34:00.000 UTC")
         .convertsFromInternal(Instant.parse("2016-07-24T20:34:12Z"))
-        .toExternal("2016-07-24T20:34:12Z")
+        .toExternal("2016-07-24 20:34:12.000 UTC")
         .convertsFromInternal(Instant.parse("2016-07-24T20:34:12.999Z"))
-        .toExternal("2016-07-24T20:34:12.999Z")
+        .toExternal("2016-07-24 20:34:12.999 UTC")
         .convertsFromInternal(Instant.parse("2016-07-24T19:34:00Z"))
-        .toExternal("2016-07-24T19:34:00Z")
+        .toExternal("2016-07-24 19:34:00.000 UTC")
         .convertsFromInternal(Instant.parse("2016-07-24T19:34:12.999Z"))
-        .toExternal("2016-07-24T19:34:12.999Z");
+        .toExternal("2016-07-24 19:34:12.999 UTC");
     codec =
         new StringToInstantCodec(
-            temporalFormat2, numberFormat, MILLISECONDS, EPOCH.atZone(UTC), nullStrings);
+            temporalFormat2, numberFormat, UTC, MILLISECONDS, EPOCH.atZone(UTC), nullStrings);
     assertThat(codec)
         .convertsFromInternal(Instant.parse("2016-07-24T20:34:12Z"))
         .toExternal("20160724203412");
     codec =
         new StringToInstantCodec(
-            temporalFormat1, numberFormat, MINUTES, millennium.atZone(UTC), nullStrings);
+            temporalFormat1, numberFormat, UTC, MINUTES, millennium.atZone(UTC), nullStrings);
     // conversion back to numeric timestamps is not possible, values are always formatted with full
     // alphanumeric pattern
     assertThat(codec)
@@ -115,7 +116,7 @@ class StringToInstantCodecTest {
   void should_not_convert_from_invalid_external() {
     StringToInstantCodec codec =
         new StringToInstantCodec(
-            temporalFormat1, numberFormat, MILLISECONDS, EPOCH.atZone(UTC), nullStrings);
+            temporalFormat1, numberFormat, UTC, MILLISECONDS, EPOCH.atZone(UTC), nullStrings);
     assertThat(codec)
         .cannotConvertFromExternal("")
         .cannotConvertFromExternal("not a valid date format");

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToIntegerCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToIntegerCodecTest.java
@@ -8,7 +8,6 @@
  */
 package com.datastax.dsbulk.engine.internal.codecs.string;
 
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.math.BigDecimal.ONE;
@@ -19,6 +18,7 @@ import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.US;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.google.common.collect.ImmutableMap;
@@ -37,7 +37,8 @@ class StringToIntegerCodecTest {
           numberFormat,
           OverflowStrategy.REJECT,
           RoundingMode.HALF_EVEN,
-          CQL_DATE_TIME_FORMAT,
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          UTC,
           MILLISECONDS,
           EPOCH.atZone(UTC),
           ImmutableMap.of("true", true, "false", false),

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToListCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToListCodecTest.java
@@ -11,7 +11,6 @@ package com.datastax.dsbulk.engine.internal.codecs.string;
 import static com.datastax.driver.core.TypeCodec.cdouble;
 import static com.datastax.driver.core.TypeCodec.list;
 import static com.datastax.driver.core.TypeCodec.varchar;
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.math.BigDecimal.ONE;
@@ -26,6 +25,7 @@ import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToDoubleCodec;
 import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToListCodec;
 import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToStringCodec;
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -50,7 +50,8 @@ class StringToListCodecTest {
           numberFormat,
           OverflowStrategy.REJECT,
           RoundingMode.HALF_EVEN,
-          CQL_DATE_TIME_FORMAT,
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          UTC,
           MILLISECONDS,
           EPOCH.atZone(UTC),
           ImmutableMap.of("true", true, "false", false),

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToLocalDateCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToLocalDateCodecTest.java
@@ -10,29 +10,26 @@ package com.datastax.dsbulk.engine.internal.codecs.string;
 
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
-import static java.time.Instant.EPOCH;
 import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.US;
 
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class StringToLocalDateCodecTest {
 
-  private DateTimeFormatter format1 =
-      CodecSettings.getDateTimeFormat("ISO_LOCAL_DATE", UTC, US, EPOCH.atZone(UTC));
+  private TemporalFormat format1 = CodecSettings.getTemporalFormat("ISO_LOCAL_DATE", null, US);
 
-  private DateTimeFormatter format2 =
-      CodecSettings.getDateTimeFormat("yyyyMMdd", UTC, US, EPOCH.atZone(UTC));
+  private TemporalFormat format2 = CodecSettings.getTemporalFormat("yyyyMMdd", null, US);
 
   private final List<String> nullStrings = newArrayList("NULL");
 
   @Test
   void should_convert_from_valid_external() {
-    StringToLocalDateCodec codec = new StringToLocalDateCodec(format1, nullStrings);
+    StringToLocalDateCodec codec = new StringToLocalDateCodec(format1, UTC, nullStrings);
     assertThat(codec)
         .convertsFromExternal("2016-07-24")
         .toInternal(LocalDate.parse("2016-07-24"))
@@ -40,21 +37,21 @@ class StringToLocalDateCodecTest {
         .toInternal(null)
         .convertsFromExternal("NULL")
         .toInternal(null);
-    codec = new StringToLocalDateCodec(format2, nullStrings);
+    codec = new StringToLocalDateCodec(format2, UTC, nullStrings);
     assertThat(codec).convertsFromExternal("20160724").toInternal(LocalDate.parse("2016-07-24"));
   }
 
   @Test
   void should_convert_from_valid_internal() {
-    StringToLocalDateCodec codec = new StringToLocalDateCodec(format1, nullStrings);
+    StringToLocalDateCodec codec = new StringToLocalDateCodec(format1, UTC, nullStrings);
     assertThat(codec).convertsFromInternal(LocalDate.parse("2016-07-24")).toExternal("2016-07-24");
-    codec = new StringToLocalDateCodec(format2, nullStrings);
+    codec = new StringToLocalDateCodec(format2, UTC, nullStrings);
     assertThat(codec).convertsFromInternal(LocalDate.parse("2016-07-24")).toExternal("20160724");
   }
 
   @Test
   void should_not_convert_from_invalid_external() {
-    StringToLocalDateCodec codec = new StringToLocalDateCodec(format1, nullStrings);
+    StringToLocalDateCodec codec = new StringToLocalDateCodec(format1, UTC, nullStrings);
     assertThat(codec)
         .cannotConvertFromExternal("")
         .cannotConvertFromExternal("not a valid date format");

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToLocalTimeCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToLocalTimeCodecTest.java
@@ -10,29 +10,26 @@ package com.datastax.dsbulk.engine.internal.codecs.string;
 
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
-import static java.time.Instant.EPOCH;
 import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.US;
 
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class StringToLocalTimeCodecTest {
 
-  private DateTimeFormatter format1 =
-      CodecSettings.getDateTimeFormat("ISO_LOCAL_TIME", UTC, US, EPOCH.atZone(UTC));
+  private TemporalFormat format1 = CodecSettings.getTemporalFormat("ISO_LOCAL_TIME", null, US);
 
-  private DateTimeFormatter format2 =
-      CodecSettings.getDateTimeFormat("HHmmss.SSS", UTC, US, EPOCH.atZone(UTC));
+  private TemporalFormat format2 = CodecSettings.getTemporalFormat("HHmmss.SSS", null, US);
 
   private final List<String> nullStrings = newArrayList("NULL");
 
   @Test
   void should_convert_from_valid_external() {
-    StringToLocalTimeCodec codec = new StringToLocalTimeCodec(format1, nullStrings);
+    StringToLocalTimeCodec codec = new StringToLocalTimeCodec(format1, UTC, nullStrings);
     assertThat(codec)
         .convertsFromExternal("12:24:46")
         .toInternal(LocalTime.parse("12:24:46"))
@@ -42,7 +39,7 @@ class StringToLocalTimeCodecTest {
         .toInternal(null)
         .convertsFromExternal("NULL")
         .toInternal(null);
-    codec = new StringToLocalTimeCodec(format2, nullStrings);
+    codec = new StringToLocalTimeCodec(format2, UTC, nullStrings);
     assertThat(codec)
         .convertsFromExternal("122446.999")
         .toInternal(LocalTime.parse("12:24:46.999"));
@@ -50,11 +47,11 @@ class StringToLocalTimeCodecTest {
 
   @Test
   void should_convert_from_valid_internal() {
-    StringToLocalTimeCodec codec = new StringToLocalTimeCodec(format1, nullStrings);
+    StringToLocalTimeCodec codec = new StringToLocalTimeCodec(format1, UTC, nullStrings);
     assertThat(codec)
         .convertsFromInternal(LocalTime.parse("12:24:46.999"))
         .toExternal("12:24:46.999");
-    codec = new StringToLocalTimeCodec(format2, nullStrings);
+    codec = new StringToLocalTimeCodec(format2, UTC, nullStrings);
     assertThat(codec)
         .convertsFromInternal(LocalTime.parse("12:24:46.999"))
         .toExternal("122446.999");
@@ -62,7 +59,7 @@ class StringToLocalTimeCodecTest {
 
   @Test
   void should_not_convert_from_invalid_external() {
-    StringToLocalTimeCodec codec = new StringToLocalTimeCodec(format1, nullStrings);
+    StringToLocalTimeCodec codec = new StringToLocalTimeCodec(format1, UTC, nullStrings);
     assertThat(codec)
         .cannotConvertFromExternal("")
         .cannotConvertFromExternal("not a valid date format");

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToLongCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToLongCodecTest.java
@@ -8,7 +8,6 @@
  */
 package com.datastax.dsbulk.engine.internal.codecs.string;
 
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.math.BigDecimal.ONE;
@@ -19,6 +18,7 @@ import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.US;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.google.common.collect.ImmutableMap;
@@ -40,7 +40,8 @@ class StringToLongCodecTest {
           numberFormat,
           OverflowStrategy.REJECT,
           RoundingMode.HALF_EVEN,
-          CQL_DATE_TIME_FORMAT,
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          UTC,
           MILLISECONDS,
           EPOCH.atZone(UTC),
           ImmutableMap.of("true", true, "false", false),

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToMapCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToMapCodecTest.java
@@ -8,7 +8,6 @@
  */
 package com.datastax.dsbulk.engine.internal.codecs.string;
 
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.math.BigDecimal.ONE;
@@ -24,6 +23,7 @@ import com.datastax.dsbulk.engine.internal.codecs.ConvertingCodec;
 import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToListCodec;
 import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToMapCodec;
 import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToStringCodec;
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -52,7 +52,8 @@ class StringToMapCodecTest {
           numberFormat,
           OverflowStrategy.REJECT,
           RoundingMode.HALF_EVEN,
-          CQL_DATE_TIME_FORMAT,
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          UTC,
           MILLISECONDS,
           EPOCH.atZone(UTC),
           ImmutableMap.of("true", true, "false", false),

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToSetCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToSetCodecTest.java
@@ -11,7 +11,6 @@ package com.datastax.dsbulk.engine.internal.codecs.string;
 import static com.datastax.driver.core.TypeCodec.cdouble;
 import static com.datastax.driver.core.TypeCodec.set;
 import static com.datastax.driver.core.TypeCodec.varchar;
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.math.BigDecimal.ONE;
@@ -27,6 +26,7 @@ import com.datastax.driver.core.TypeCodec;
 import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToDoubleCodec;
 import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToSetCodec;
 import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToStringCodec;
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -52,7 +52,8 @@ class StringToSetCodecTest {
           numberFormat,
           OverflowStrategy.REJECT,
           RoundingMode.HALF_EVEN,
-          CQL_DATE_TIME_FORMAT,
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          UTC,
           MILLISECONDS,
           EPOCH.atZone(UTC),
           ImmutableMap.of("true", true, "false", false),

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToShortCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToShortCodecTest.java
@@ -8,7 +8,6 @@
  */
 package com.datastax.dsbulk.engine.internal.codecs.string;
 
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.math.BigDecimal.ONE;
@@ -19,6 +18,7 @@ import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.US;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.google.common.collect.ImmutableMap;
@@ -37,7 +37,8 @@ class StringToShortCodecTest {
           numberFormat,
           OverflowStrategy.REJECT,
           RoundingMode.HALF_EVEN,
-          CQL_DATE_TIME_FORMAT,
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          UTC,
           MILLISECONDS,
           EPOCH.atZone(UTC),
           ImmutableMap.of("true", true, "false", false),

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToTupleCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToTupleCodecTest.java
@@ -12,7 +12,6 @@ import static com.datastax.driver.core.DataType.timestamp;
 import static com.datastax.driver.core.DataType.varchar;
 import static com.datastax.driver.core.DriverCoreEngineTestHooks.newTupleType;
 import static com.datastax.driver.core.ProtocolVersion.V4;
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.math.RoundingMode.HALF_EVEN;
@@ -29,6 +28,7 @@ import com.datastax.dsbulk.engine.internal.codecs.ConvertingCodec;
 import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToInstantCodec;
 import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToStringCodec;
 import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToTupleCodec;
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -54,7 +54,12 @@ class StringToTupleCodecTest {
 
   private final ConvertingCodec eltCodec1 =
       new JsonNodeToInstantCodec(
-          CQL_DATE_TIME_FORMAT, numberFormat, MILLISECONDS, EPOCH.atZone(UTC), nullStrings);
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          numberFormat,
+          UTC,
+          MILLISECONDS,
+          EPOCH.atZone(UTC),
+          nullStrings);
 
   private final ConvertingCodec eltCodec2 =
       new JsonNodeToStringCodec(TypeCodec.varchar(), objectMapper, nullStrings);
@@ -102,7 +107,7 @@ class StringToTupleCodecTest {
     assertThat(codec)
         .convertsFromInternal(
             tupleType.newValue(Instant.parse("2016-07-24T20:34:12.999Z"), "+01:00"))
-        .toExternal("[\"2016-07-24T20:34:12.999Z\",\"+01:00\"]")
+        .toExternal("[\"2016-07-24 20:34:12.999 UTC\",\"+01:00\"]")
         .convertsFromInternal(tupleType.newValue(null, null))
         .toExternal("[null,null]")
         .convertsFromInternal(null)

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToUDTCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToUDTCodecTest.java
@@ -17,7 +17,6 @@ import static com.datastax.driver.core.DataType.varchar;
 import static com.datastax.driver.core.DriverCoreEngineTestHooks.newField;
 import static com.datastax.driver.core.DriverCoreEngineTestHooks.newUserType;
 import static com.datastax.driver.core.TypeCodec.userType;
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.math.BigDecimal.ONE;
@@ -40,6 +39,7 @@ import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToListCodec;
 import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToLocalDateCodec;
 import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToMapCodec;
 import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToUDTCodec;
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -80,7 +80,8 @@ class StringToUDTCodecTest {
           numberFormat,
           OverflowStrategy.REJECT,
           RoundingMode.HALF_EVEN,
-          CQL_DATE_TIME_FORMAT,
+          CqlTemporalFormat.DEFAULT_INSTANCE,
+          UTC,
           MILLISECONDS,
           EPOCH.atZone(UTC),
           ImmutableMap.of("true", true, "false", false),
@@ -94,7 +95,8 @@ class StringToUDTCodecTest {
               numberFormat,
               OverflowStrategy.REJECT,
               RoundingMode.HALF_EVEN,
-              CQL_DATE_TIME_FORMAT,
+              CqlTemporalFormat.DEFAULT_INSTANCE,
+              UTC,
               MILLISECONDS,
               EPOCH.atZone(UTC),
               ImmutableMap.of("true", true, "false", false),
@@ -136,7 +138,7 @@ class StringToUDTCodecTest {
   private final ConvertingCodec f2bCodec =
       new JsonNodeToListCodec<>(
           TypeCodec.list(LocalDateCodec.instance),
-          new JsonNodeToLocalDateCodec(CQL_DATE_TIME_FORMAT, nullStrings),
+          new JsonNodeToLocalDateCodec(CqlTemporalFormat.DEFAULT_INSTANCE, nullStrings),
           objectMapper,
           nullStrings);
 

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToUUIDCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/string/StringToUUIDCodecTest.java
@@ -12,7 +12,6 @@ import static com.datastax.dsbulk.engine.internal.codecs.util.TimeUUIDGenerator.
 import static com.datastax.dsbulk.engine.internal.codecs.util.TimeUUIDGenerator.MAX;
 import static com.datastax.dsbulk.engine.internal.codecs.util.TimeUUIDGenerator.MIN;
 import static com.datastax.dsbulk.engine.internal.codecs.util.TimeUUIDGenerator.RANDOM;
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.math.RoundingMode.HALF_EVEN;
@@ -40,7 +39,12 @@ class StringToUUIDCodecTest {
 
   private StringToInstantCodec instantCodec =
       new StringToInstantCodec(
-          CQL_DATE_TIME_FORMAT, numberFormat, MILLISECONDS, EPOCH.atZone(UTC), nullStrings);
+          CodecSettings.getTemporalFormat("yyyy-MM-dd'T'HH:mm:ss[.SSSSSSSSS]XXX", UTC, US),
+          numberFormat,
+          UTC,
+          MILLISECONDS,
+          EPOCH.atZone(UTC),
+          nullStrings);
 
   private final StringToUUIDCodec codec =
       new StringToUUIDCodec(TypeCodec.uuid(), instantCodec, MIN, nullStrings);

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/temporal/TemporalToUUIDCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/temporal/TemporalToUUIDCodecTest.java
@@ -110,4 +110,21 @@ class TemporalToUUIDCodecTest {
                             .toEpochMilli())))
         .isEqualTo(ZonedDateTime.parse("2010-06-30T00:00:00.999+01:00"));
   }
+
+  public static void main(String[] args) {
+    long n = 123400000;
+    System.out.println(n + ceiling(n));
+  }
+
+  public static long ceiling(long n) {
+    if (n == 0) {
+      return 0;
+    }
+    int adjustment = 1;
+    while (n % 10 == 0) {
+      adjustment *= 10;
+      n /= 10;
+    }
+    return adjustment - 1;
+  }
 }

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/util/CqlTemporalFormatTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/util/CqlTemporalFormatTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.util;
+
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+import static java.util.Locale.US;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.Lists;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CqlTemporalFormatTest {
+
+  private final Instant i1 = Instant.parse("2017-11-23T12:24:59Z");
+  private final Instant i2 = Instant.parse("2018-02-01T00:00:00Z");
+
+  private final TemporalFormat format = CqlTemporalFormat.DEFAULT_INSTANCE;
+
+  // all valid CQL patterns, as used in Cassandra 2.2+
+  private final List<String> patterns =
+      Lists.newArrayList(
+          "yyyy-MM-dd HH:mm",
+          "yyyy-MM-dd HH:mm:ss",
+          "yyyy-MM-dd HH:mm z",
+          "yyyy-MM-dd HH:mm zz",
+          "yyyy-MM-dd HH:mm zzz",
+          "yyyy-MM-dd HH:mmX",
+          "yyyy-MM-dd HH:mmXX",
+          "yyyy-MM-dd HH:mmXXX",
+          "yyyy-MM-dd HH:mm:ss",
+          "yyyy-MM-dd HH:mm:ss z",
+          "yyyy-MM-dd HH:mm:ss zz",
+          "yyyy-MM-dd HH:mm:ss zzz",
+          "yyyy-MM-dd HH:mm:ssX",
+          "yyyy-MM-dd HH:mm:ssXX",
+          "yyyy-MM-dd HH:mm:ssXXX",
+          "yyyy-MM-dd HH:mm:ss.SSS",
+          "yyyy-MM-dd HH:mm:ss.SSS z",
+          "yyyy-MM-dd HH:mm:ss.SSS zz",
+          "yyyy-MM-dd HH:mm:ss.SSS zzz",
+          "yyyy-MM-dd HH:mm:ss.SSSX",
+          "yyyy-MM-dd HH:mm:ss.SSSXX",
+          "yyyy-MM-dd HH:mm:ss.SSSXXX",
+          "yyyy-MM-dd'T'HH:mm",
+          "yyyy-MM-dd'T'HH:mm z",
+          "yyyy-MM-dd'T'HH:mm zz",
+          "yyyy-MM-dd'T'HH:mm zzz",
+          "yyyy-MM-dd'T'HH:mmX",
+          "yyyy-MM-dd'T'HH:mmXX",
+          "yyyy-MM-dd'T'HH:mmXXX",
+          "yyyy-MM-dd'T'HH:mm:ss",
+          "yyyy-MM-dd'T'HH:mm:ss z",
+          "yyyy-MM-dd'T'HH:mm:ss zz",
+          "yyyy-MM-dd'T'HH:mm:ss zzz",
+          "yyyy-MM-dd'T'HH:mm:ssX",
+          "yyyy-MM-dd'T'HH:mm:ssXX",
+          "yyyy-MM-dd'T'HH:mm:ssXXX",
+          "yyyy-MM-dd'T'HH:mm:ss.SSS",
+          "yyyy-MM-dd'T'HH:mm:ss.SSS z",
+          "yyyy-MM-dd'T'HH:mm:ss.SSS zz",
+          "yyyy-MM-dd'T'HH:mm:ss.SSS zzz",
+          "yyyy-MM-dd'T'HH:mm:ss.SSSX",
+          "yyyy-MM-dd'T'HH:mm:ss.SSSXX",
+          "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
+          "yyyy-MM-dd",
+          "yyyy-MM-dd z",
+          "yyyy-MM-dd zz",
+          "yyyy-MM-dd zzz",
+          "yyyy-MM-ddX",
+          "yyyy-MM-ddXX",
+          "yyyy-MM-ddXXX");
+
+  private final List<ZoneId> zones =
+      Lists.newArrayList(
+          ZoneId.of("UTC"),
+          ZoneId.of("Z"),
+          ZoneId.of("GMT"),
+          ZoneId.of("GMT+2"),
+          ZoneId.of("UTC+01:00"),
+          ZoneId.of("+02:00"),
+          ZoneId.of("PST", ZoneId.SHORT_IDS),
+          ZoneId.of("CET", ZoneId.SHORT_IDS),
+          ZoneId.of("-08"),
+          ZoneId.of("-0830"),
+          ZoneId.of("-08:30"),
+          ZoneId.of("-083015"),
+          ZoneId.of("-08:30:15"));
+
+  @Test
+  void should_parse_temporal() {
+    assertThat(format.parse(null)).isNull();
+    assertThat(Instant.from(format.parse("2017-11-23T13:24:59.000 CEST"))).isEqualTo(i1);
+    assertThat(Instant.from(format.parse("2017-11-23T13:24:59 CEST"))).isEqualTo(i1);
+    assertThat(Instant.from(format.parse("2017-11-23T14:24:59+02:00"))).isEqualTo(i1);
+    assertThat(Instant.from(format.parse("2017-11-23T12:24:59"))).isEqualTo(i1);
+    assertThat(Instant.from(format.parse("2018-02-01"))).isEqualTo(i2);
+    assertThat(Instant.from(format.parse("2018-02-01T00:00"))).isEqualTo(i2);
+    assertThat(Instant.from(format.parse("2018-02-01T00:00:00"))).isEqualTo(i2);
+    assertThat(Instant.from(format.parse("2018-02-01T00:00:00Z"))).isEqualTo(i2);
+  }
+
+  @Test
+  void should_format_temporal() {
+    assertThat(format.format(Instant.parse("2017-11-23T14:24:59.999Z")))
+        .isEqualTo("2017-11-23 14:24:59.999 UTC");
+  }
+
+  @Test
+  void should_parse_all_valid_cql_literals() {
+    for (String pattern : patterns) {
+      for (ZoneId zone : zones) {
+        boolean zoned = pattern.contains("X") || pattern.contains("z");
+        if (zoned && zone instanceof ZoneOffset) {
+          int offset = ((ZoneOffset) zone).getTotalSeconds();
+          int normalized = (offset / 60) * 60;
+          // offsets including minutes cannot be properly parsed/formatted with valid CQL formats
+          if (offset != normalized) {
+            continue;
+          }
+        }
+        CqlTemporalFormat format = new CqlTemporalFormat(zone, US);
+        DateTimeFormatter f =
+            new DateTimeFormatterBuilder()
+                .parseStrict()
+                .parseCaseInsensitive()
+                .appendPattern(pattern)
+                .parseDefaulting(HOUR_OF_DAY, 0)
+                .parseDefaulting(MINUTE_OF_HOUR, 0)
+                .parseDefaulting(SECOND_OF_MINUTE, 0)
+                .parseDefaulting(NANO_OF_SECOND, 0)
+                .toFormatter(US)
+                .withZone(zone);
+        String input = f.format(i1);
+        TemporalAccessor expected = f.parse(input);
+        TemporalAccessor actual = format.parse(input);
+        long actualSeconds;
+        if (actual instanceof ZonedDateTime) {
+          actualSeconds = ((ZonedDateTime) actual).toEpochSecond();
+        } else {
+          actualSeconds = actual.getLong(ChronoField.INSTANT_SECONDS);
+        }
+        long expectedSeconds = expected.getLong(ChronoField.INSTANT_SECONDS);
+        assertThat(actualSeconds)
+            .overridingErrorMessage(
+                "Expecting %s to be same instant as %s but it was not", actual, i1)
+            .isEqualTo(expectedSeconds);
+      }
+    }
+  }
+
+  @Test
+  void should_format_all_valid_cql_literals() {
+    for (ZoneId zone : zones) {
+      DateTimeFormatter f =
+          DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss.SSS zzz").withZone(zone);
+      CqlTemporalFormat format = new CqlTemporalFormat(zone, US);
+      String actual = format.format(i1);
+      String expected = f.format(i1);
+      assertThat(actual).isEqualTo(expected);
+    }
+  }
+}

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/util/SimpleTemporalFormatTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/util/SimpleTemporalFormatTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.util;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.junit.jupiter.api.Test;
+
+class SimpleTemporalFormatTest {
+
+  private final TemporalFormat localDateFormat = new SimpleTemporalFormat(ISO_LOCAL_DATE);
+
+  private final TemporalFormat localTimeFormat = new SimpleTemporalFormat(ISO_LOCAL_TIME);
+
+  @Test
+  void should_parse_temporal() {
+    assertThat(LocalDate.from(localDateFormat.parse("2018-02-01")))
+        .isEqualTo(LocalDate.parse("2018-02-01"));
+    assertThat(LocalTime.from(localTimeFormat.parse("13:24:59.123456789")))
+        .isEqualTo(LocalTime.parse("13:24:59.123456789"));
+    assertThat(LocalTime.from(localTimeFormat.parse("13:24:59")))
+        .isEqualTo(LocalTime.parse("13:24:59"));
+    assertThat(LocalTime.from(localTimeFormat.parse("13:24")))
+        .isEqualTo(LocalTime.parse("13:24:00"));
+  }
+
+  @Test
+  void should_format_temporal() {
+    assertThat(localDateFormat.format(LocalDate.parse("2018-02-01"))).isEqualTo("2018-02-01");
+    assertThat(localTimeFormat.format(LocalTime.parse("14:24:59.999"))).isEqualTo("14:24:59.999");
+  }
+}

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/util/ZonedTemporalFormatTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/util/ZonedTemporalFormatTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.dsbulk.engine.internal.codecs.util;
+
+import static java.time.ZoneOffset.ofHours;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import org.junit.jupiter.api.Test;
+
+class ZonedTemporalFormatTest {
+
+  private final Instant i = Instant.parse("2017-11-23T12:24:59Z");
+
+  private final TemporalFormat format1 =
+      new ZonedTemporalFormat(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"), ofHours(2));
+  private final TemporalFormat format2 =
+      new ZonedTemporalFormat(DateTimeFormatter.ofPattern("yyyyMMddHHmmss[XXX]"), ofHours(2));
+
+  @Test
+  void should_parse_temporal() {
+    assertThat(format1.parse(null)).isNull();
+    assertThat(Instant.from(format1.parse("20171123142459"))).isEqualTo(i);
+    assertThat(Instant.from(format2.parse("20171123142459"))).isEqualTo(i);
+    assertThat(Instant.from(format2.parse("20171123142459+02:00"))).isEqualTo(i);
+    assertThat(Instant.from(format2.parse("20171123152459+03:00"))).isEqualTo(i);
+    assertThat(Instant.from(format2.parse("20171123202459+08:00"))).isEqualTo(i);
+  }
+
+  @Test
+  void should_format_temporal() {
+    assertThat(format1.format(Instant.parse("2017-11-23T14:24:59.999Z")))
+        .isEqualTo("20171123162459"); // at +02:00
+    assertThat(format2.format(Instant.parse("2017-11-23T14:24:59.999Z")))
+        .isEqualTo("20171123162459+02:00");
+  }
+}

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/writetime/WriteTimeCodecTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/codecs/writetime/WriteTimeCodecTest.java
@@ -11,6 +11,7 @@ package com.datastax.dsbulk.engine.internal.codecs.writetime;
 import static com.datastax.dsbulk.engine.tests.EngineAssertions.assertThat;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.math.RoundingMode.HALF_EVEN;
+import static java.time.Instant.EPOCH;
 import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.US;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -20,13 +21,13 @@ import com.datastax.dsbulk.engine.internal.codecs.json.JsonNodeToInstantCodec;
 import com.datastax.dsbulk.engine.internal.codecs.string.StringToInstantCodec;
 import com.datastax.dsbulk.engine.internal.codecs.temporal.DateToTemporalCodec;
 import com.datastax.dsbulk.engine.internal.codecs.temporal.TemporalToTemporalCodec;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.sql.Timestamp;
 import java.text.NumberFormat;
 import java.time.Instant;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -36,10 +37,10 @@ class WriteTimeCodecTest {
 
   private final TimeUnit unit = MILLISECONDS;
 
-  private final ZonedDateTime epoch = Instant.EPOCH.atZone(UTC);
+  private final ZonedDateTime epoch = EPOCH.atZone(UTC);
 
-  private final DateTimeFormatter temporalFormat =
-      CodecSettings.getDateTimeFormat("CQL_DATE_TIME", UTC, US, epoch);
+  private final TemporalFormat temporalFormat =
+      CodecSettings.getTemporalFormat("CQL_DATE_TIME", UTC, US);
 
   private final FastThreadLocal<NumberFormat> numberFormat =
       CodecSettings.getNumberFormatThreadLocal("#,###.##", US, HALF_EVEN, true);
@@ -51,7 +52,8 @@ class WriteTimeCodecTest {
 
     assertThat(
             new WriteTimeCodec<>(
-                new StringToInstantCodec(temporalFormat, numberFormat, unit, epoch, nullStrings)))
+                new StringToInstantCodec(
+                    temporalFormat, numberFormat, UTC, unit, epoch, nullStrings)))
         .convertsFromExternal("2017-11-30T14:46:56+01:00")
         .toInternal(
             MILLISECONDS.toMicros(
@@ -59,13 +61,15 @@ class WriteTimeCodecTest {
 
     assertThat(
             new WriteTimeCodec<>(
-                new StringToInstantCodec(temporalFormat, numberFormat, unit, epoch, nullStrings)))
+                new StringToInstantCodec(
+                    temporalFormat, numberFormat, UTC, unit, epoch, nullStrings)))
         .convertsFromExternal("123456")
         .toInternal(MILLISECONDS.toMicros(123456L));
 
     assertThat(
             new WriteTimeCodec<>(
-                new JsonNodeToInstantCodec(temporalFormat, numberFormat, unit, epoch, nullStrings)))
+                new JsonNodeToInstantCodec(
+                    temporalFormat, numberFormat, UTC, unit, epoch, nullStrings)))
         .convertsFromExternal(CodecSettings.JSON_NODE_FACTORY.textNode("2017-11-30T14:46:56+01:00"))
         .toInternal(
             MILLISECONDS.toMicros(
@@ -73,13 +77,15 @@ class WriteTimeCodecTest {
 
     assertThat(
             new WriteTimeCodec<>(
-                new JsonNodeToInstantCodec(temporalFormat, numberFormat, unit, epoch, nullStrings)))
+                new JsonNodeToInstantCodec(
+                    temporalFormat, numberFormat, UTC, unit, epoch, nullStrings)))
         .convertsFromExternal(CodecSettings.JSON_NODE_FACTORY.textNode("123456"))
         .toInternal(MILLISECONDS.toMicros(123456L));
 
     assertThat(
             new WriteTimeCodec<>(
-                new JsonNodeToInstantCodec(temporalFormat, numberFormat, unit, epoch, nullStrings)))
+                new JsonNodeToInstantCodec(
+                    temporalFormat, numberFormat, UTC, unit, epoch, nullStrings)))
         .convertsFromExternal(CodecSettings.JSON_NODE_FACTORY.numberNode(123456L))
         .toInternal(MILLISECONDS.toMicros(123456L));
 

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/schema/DefaultMappingTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/schema/DefaultMappingTest.java
@@ -46,7 +46,8 @@ class DefaultMappingTest {
   @Test
   void should_detect_writetime_variable() {
     ExtendedCodecRegistry extendedCodecRegistry = mock(ExtendedCodecRegistry.class);
-    ConvertingCodec<String, Instant> codec = new StringToInstantCodec(null, null, null, null, null);
+    ConvertingCodec<String, Instant> codec =
+        new StringToInstantCodec(null, null, null, null, null, null);
     when(extendedCodecRegistry.<String, Instant>convertingCodecFor(
             timestamp(), TypeToken.of(String.class)))
         .thenReturn(codec);

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/schema/DefaultRecordMapperTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/schema/DefaultRecordMapperTest.java
@@ -10,7 +10,6 @@ package com.datastax.dsbulk.engine.internal.schema;
 
 import static com.datastax.driver.core.DataType.bigint;
 import static com.datastax.driver.core.ProtocolVersion.V4;
-import static com.datastax.dsbulk.engine.internal.settings.CodecSettings.CQL_DATE_TIME_FORMAT;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.ZERO;
@@ -41,7 +40,10 @@ import com.datastax.dsbulk.connectors.api.RecordMetadata;
 import com.datastax.dsbulk.connectors.api.internal.DefaultRecordMetadata;
 import com.datastax.dsbulk.engine.internal.codecs.string.StringToIntegerCodec;
 import com.datastax.dsbulk.engine.internal.codecs.string.StringToLongCodec;
+import com.datastax.dsbulk.engine.internal.codecs.util.CqlTemporalFormat;
 import com.datastax.dsbulk.engine.internal.codecs.util.OverflowStrategy;
+import com.datastax.dsbulk.engine.internal.codecs.util.TemporalFormat;
+import com.datastax.dsbulk.engine.internal.codecs.util.ZonedTemporalFormat;
 import com.datastax.dsbulk.engine.internal.settings.CodecSettings;
 import com.datastax.dsbulk.engine.internal.statement.UnmappableStatement;
 import com.google.common.collect.ImmutableMap;
@@ -51,7 +53,6 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 import java.text.NumberFormat;
 import java.time.Instant;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Set;
@@ -205,7 +206,8 @@ class DefaultRecordMapperTest {
                 formatter,
                 OverflowStrategy.REJECT,
                 HALF_EVEN,
-                CQL_DATE_TIME_FORMAT,
+                CqlTemporalFormat.DEFAULT_INSTANCE,
+                UTC,
                 MINUTES,
                 EPOCH.atZone(UTC),
                 ImmutableMap.of("true", true, "false", false),
@@ -241,7 +243,8 @@ class DefaultRecordMapperTest {
                 formatter,
                 OverflowStrategy.REJECT,
                 HALF_EVEN,
-                CQL_DATE_TIME_FORMAT,
+                CqlTemporalFormat.DEFAULT_INSTANCE,
+                UTC,
                 MINUTES,
                 millennium.atZone(UTC),
                 ImmutableMap.of("true", true, "false", false),
@@ -275,7 +278,8 @@ class DefaultRecordMapperTest {
                 formatter,
                 OverflowStrategy.REJECT,
                 HALF_EVEN,
-                CQL_DATE_TIME_FORMAT,
+                CqlTemporalFormat.DEFAULT_INSTANCE,
+                UTC,
                 MILLISECONDS,
                 EPOCH.atZone(UTC),
                 ImmutableMap.of("true", true, "false", false),
@@ -306,8 +310,8 @@ class DefaultRecordMapperTest {
     when(record.fields()).thenReturn(set(F1));
     when(variables.getType(C1)).thenReturn(bigint());
     when(record.getFieldValue(F1)).thenReturn("20171123-123456");
-    DateTimeFormatter timestampFormat =
-        DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss").withZone(ZoneOffset.UTC);
+    TemporalFormat timestampFormat =
+        new ZonedTemporalFormat(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"), UTC);
     StringToLongCodec codec =
         spy(
             new StringToLongCodec(
@@ -315,6 +319,7 @@ class DefaultRecordMapperTest {
                 OverflowStrategy.REJECT,
                 HALF_EVEN,
                 timestampFormat,
+                UTC,
                 MILLISECONDS,
                 EPOCH.atZone(UTC),
                 ImmutableMap.of("true", true, "false", false),

--- a/manual/application.template.conf
+++ b/manual/application.template.conf
@@ -537,7 +537,7 @@ dsbulk {
 
     # The temporal pattern to use for `String` to CQL date conversions. Valid choices:
     # 
-    # - A date-time pattern such as `uuuu-MM-dd`.
+    # - A date-time pattern such as `yyyy-MM-dd`.
     # - A pre-defined formatter such as `ISO_LOCAL_DATE`. Any public static field in
     # `java.time.format.DateTimeFormatter` can be used.
     # 
@@ -707,7 +707,7 @@ dsbulk {
 
     # The temporal pattern to use for `String` to CQL timestamp conversions. Valid choices:
     # 
-    # - A date-time pattern such as `uuuu-MM-dd HH:mm:ss`.
+    # - A date-time pattern such as `yyyy-MM-dd HH:mm:ss`.
     # - A pre-defined formatter such as `ISO_ZONED_DATE_TIME` or `ISO_INSTANT`. Any public static
     # field in `java.time.format.DateTimeFormatter` can be used.
     # - The special value `CQL_DATE_TIME`, which is a special parser that accepts most CQL date,
@@ -720,41 +720,10 @@ dsbulk {
     # timestamp
     # format](https://docs.datastax.com/en/dse/5.1/cql/cql/cql_reference/refDateTimeFormats.html?hl=timestamp).
     # 
-    # The default value is the special `CQL_DATE_TIME` value. This format is roughly equivalent to
-    # the pre-defined `ISO_ZONED_DATE_TIME`, but is more permissive regarding missing fields and
-    # time zone formats.
-    # 
-    # When parsing, this format recognizes most CQL temporal literals, e.g.:
-    # 
-    # - Local dates:
-    # - `2012-01-01`
-    # - Local times:
-    # - `12:34`
-    # - `12:34:56`
-    # - `12:34:56.123`
-    # - `12:34:56.123456`
-    # - `12:34:56.123456789`
-    # - Local date-times:
-    # - `2012-01-01T12:34`
-    # - `2012-01-01T12:34:56`
-    # - `2012-01-01T12:34:56.123`
-    # - `2012-01-01T12:34:56.123456`
-    # - `2012-01-01T12:34:56.123456789`
-    # - Zoned date-times:
-    # - `2012-01-01T12:34+01:00`
-    # - `2012-01-01T12:34:56+01:00`
-    # - `2012-01-01T12:34:56.123+01:00`
-    # - `2012-01-01T12:34:56.123456+01:00`
-    # - `2012-01-01T12:34:56.123456789+01:00`
-    # - `2012-01-01T12:34:56.123456789+01:00[Europe/Paris]`
-    # 
-    # When the input is a local date, the timestamp is resolved using the time zone specified under
-    # `timeZone`, at midnight. When the input is a local time, the timestamp is resolved using the
-    # time zone specified under `timeZone`, and the date is inferred from the instant specified
-    # under `epoch` (by default, January 1st 1970).
-    # 
-    # When formatting, this format is equivalent to `ISO_ZONED_DATE_TIME`, and produces formatted
-    # output of the following form: '2011-12-03T10:15:30.567+01:00[Europe/Paris]'.
+    # The default value is the special `CQL_DATE_TIME` value. When parsing, this format recognizes
+    # all CQL temporal literals; if the input is a local date, the timestamp is resolved using the
+    # time zone specified under `timeZone`, at midnight. When formatting, this format produces
+    # formatted output of the following form: '2011-12-03 10:15:30.567 CEST'.
     # Type: string
     # Default value: "CQL_DATE_TIME"
     #codec.timestamp = "CQL_DATE_TIME"

--- a/manual/settings.md
+++ b/manual/settings.md
@@ -645,7 +645,7 @@ Default: **["1:0","Y:N","T:F","YES:NO","TRUE:FALSE"]**.
 
 The temporal pattern to use for `String` to CQL date conversions. Valid choices:
 
-- A date-time pattern such as `uuuu-MM-dd`.
+- A date-time pattern such as `yyyy-MM-dd`.
 - A pre-defined formatter such as `ISO_LOCAL_DATE`. Any public static field in `java.time.format.DateTimeFormatter` can be used.
 
 For more information on patterns and pre-defined formatters, see [https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns).
@@ -767,7 +767,7 @@ Default: **"UTC"**.
 
 The temporal pattern to use for `String` to CQL timestamp conversions. Valid choices:
 
-- A date-time pattern such as `uuuu-MM-dd HH:mm:ss`.
+- A date-time pattern such as `yyyy-MM-dd HH:mm:ss`.
 - A pre-defined formatter such as `ISO_ZONED_DATE_TIME` or `ISO_INSTANT`. Any public static field in `java.time.format.DateTimeFormatter` can be used.
 - The special value `CQL_DATE_TIME`, which is a special parser that accepts most CQL date, time and timestamp literals (see below).
 
@@ -775,35 +775,7 @@ For more information on patterns and pre-defined formatters, see [https://docs.o
 
 For more information about CQL date, time and timestamp literals, see [Date, time, and timestamp format](https://docs.datastax.com/en/dse/5.1/cql/cql/cql_reference/refDateTimeFormats.html?hl=timestamp).
 
-The default value is the special `CQL_DATE_TIME` value. This format is roughly equivalent to the pre-defined `ISO_ZONED_DATE_TIME`, but is more permissive regarding missing fields and time zone formats.
-
-When parsing, this format recognizes most CQL temporal literals, e.g.:
-
-- Local dates:
-    - `2012-01-01`
-- Local times:
-    - `12:34`
-    - `12:34:56`
-    - `12:34:56.123`
-    - `12:34:56.123456`
-    - `12:34:56.123456789`
-- Local date-times:
-    - `2012-01-01T12:34`
-    - `2012-01-01T12:34:56`
-    - `2012-01-01T12:34:56.123`
-    - `2012-01-01T12:34:56.123456`
-    - `2012-01-01T12:34:56.123456789`
-- Zoned date-times:
-    - `2012-01-01T12:34+01:00`
-    - `2012-01-01T12:34:56+01:00`
-    - `2012-01-01T12:34:56.123+01:00`
-    - `2012-01-01T12:34:56.123456+01:00`
-    - `2012-01-01T12:34:56.123456789+01:00`
-    - `2012-01-01T12:34:56.123456789+01:00[Europe/Paris]`
-
-When the input is a local date, the timestamp is resolved using the time zone specified under `timeZone`, at midnight. When the input is a local time, the timestamp is resolved using the time zone specified under `timeZone`, and the date is inferred from the instant specified under `epoch` (by default, January 1st 1970).
-
-When formatting, this format is equivalent to `ISO_ZONED_DATE_TIME`, and produces formatted output of the following form: '2011-12-03T10:15:30.567+01:00[Europe/Paris]'.
+The default value is the special `CQL_DATE_TIME` value. When parsing, this format recognizes all CQL temporal literals; if the input is a local date, the timestamp is resolved using the time zone specified under `timeZone`, at midnight. When formatting, this format produces formatted output of the following form: '2011-12-03 10:15:30.567 CEST'.
 
 Default: **"CQL_DATE_TIME"**.
 


### PR DESCRIPTION
Summary of changes:

1. Created a new `TemporalFormat` interface to encapsulate `DateTimeFormatter` instances.
2. Created a new `CqlTemporalFormat` class. Its parser accepts now all valid CQL formats; its formatter now prints timestamps using a format the is also CQL compliant: `yyyy-MM-dd HH:mm:ss.SSS zzz`.
3. Fixed problems related to time zones. When parsing, it is dangerous to force a time zone on the parser by calling `DateTimeFormatter.withZone()`: if the parser recognizes zones, forcing a default zone will override the zone contained in the input data and could result in data corruption.