### PR TITLE
DAT-338 Allow to set custom end of line charater for CSV connector

### DIFF
--- a/connectors/csv/src/main/resources/reference.conf
+++ b/connectors/csv/src/main/resources/reference.conf
@@ -65,7 +65,7 @@ dsbulk {
     # The character that represents a line comment when found in the beginning of a line of text. Only one character can be specified. Note that this setting applies to all files to be read or written. This feature is disabled by default (indicated by its `null` character value).
     comment = "\u0000"
 
-    # The character(s) that represent end of line (EOL).  When set to 'auto' (default), uses the system's EOL and auto-detection of EOL when reading the data. Character could be specified with Java syntax, "\r\n", for example.
+    # The character(s) that represent a line ending. When set to the special value auto (default), the system's line separator, as determined by System.lineSeparator(), will be used when writing, and auto-detection of line endings will be enabled when reading. Only one or two characters can be specified; beware that most typical line separator characters need to be escaped, e.g. one should specify \r\n for the typical line ending on Windows systems (carriage return followed by a new line).
     newline = "auto"
 
     # The number of records to skip from each input file before the parser can begin to execute. Note that if the file contains a header line, that line is not counted as a valid record. This setting is ignored when writing.

--- a/connectors/csv/src/test/java/com/datastax/dsbulk/connectors/csv/CSVConnectorTest.java
+++ b/connectors/csv/src/test/java/com/datastax/dsbulk/connectors/csv/CSVConnectorTest.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.datastax.dsbulk.commons.config.BulkConfigurationException;
 import com.datastax.dsbulk.commons.config.LoaderConfig;
 import com.datastax.dsbulk.commons.internal.config.DefaultLoaderConfig;
 import com.datastax.dsbulk.commons.tests.HttpTestServer;
@@ -631,6 +632,22 @@ class CSVConnectorTest {
     } finally {
       deleteDirectory(out);
     }
+  }
+
+  @Test()
+  void should_error_when_newline_is_wrong() throws Exception {
+    CSVConnector connector = new CSVConnector();
+    // empty string test
+    LoaderConfig settings1 =
+        new DefaultLoaderConfig(
+            ConfigFactory.parseString("newline = \"\"").withFallback(CONNECTOR_DEFAULT_SETTINGS));
+    assertThrows(BulkConfigurationException.class, () -> connector.configure(settings1, false));
+    // long string test
+    LoaderConfig settings2 =
+        new DefaultLoaderConfig(
+            ConfigFactory.parseString("newline = \"abc\"")
+                .withFallback(CONNECTOR_DEFAULT_SETTINGS));
+    assertThrows(BulkConfigurationException.class, () -> connector.configure(settings2, false));
   }
 
   @Test

--- a/manual/application.template.conf
+++ b/manual/application.template.conf
@@ -169,9 +169,12 @@ dsbulk {
     # Default value: "0.25C"
     #connector.csv.maxConcurrentFiles = "0.25C"
 
-    # The character(s) that represent end of line (EOL).  When set to 'auto' (default), uses the
-    # system's EOL and auto-detection of EOL when reading the data. Character could be specified
-    # with Java syntax, "\r\n", for example.
+    # The character(s) that represent a line ending. When set to the special value auto (default),
+    # the system's line separator, as determined by System.lineSeparator(), will be used when
+    # writing, and auto-detection of line endings will be enabled when reading. Only one or two
+    # characters can be specified; beware that most typical line separator characters need to be
+    # escaped, e.g. one should specify \r\n for the typical line ending on Windows systems (carriage
+    # return followed by a new line).
     # Type: string
     # Default value: "auto"
     #connector.csv.newline = "auto"

--- a/manual/settings.md
+++ b/manual/settings.md
@@ -379,7 +379,7 @@ Default: **"0.25C"**.
 
 #### -newline,--connector.csv.newline _&lt;string&gt;_
 
-The character(s) that represent end of line (EOL).  When set to 'auto' (default), uses the system's EOL and auto-detection of EOL when reading the data. Character could be specified with Java syntax, "\r\n", for example.
+The character(s) that represent a line ending. When set to the special value auto (default), the system's line separator, as determined by System.lineSeparator(), will be used when writing, and auto-detection of line endings will be enabled when reading. Only one or two characters can be specified; beware that most typical line separator characters need to be escaped, e.g. one should specify \r\n for the typical line ending on Windows systems (carriage return followed by a new line).
 
 Default: **"auto"**.
 


### PR DESCRIPTION
This adds a new flag to CSV connector (-newline) that allows to specify the sequence of characters that will be treated as newline. Default value of this flag is auto - that means that CSV reader/writer will use autodetection, and system EOL characters. If flag is set to something different, then autodetection on reading is disabled, and when writing happens, "normalization" of embedded EOL characters won't happen as well.

Data sample & schema for testing are attached to JIRA. Unit test is added.