### PR TITLE
Fix incorrect COUNT query generation

### DIFF
--- a/engine/src/main/java/com/datastax/dsbulk/engine/internal/settings/SchemaSettings.java
+++ b/engine/src/main/java/com/datastax/dsbulk/engine/internal/settings/SchemaSettings.java
@@ -988,16 +988,8 @@ public class SchemaSettings {
 
   @NotNull
   private String getGlobalCountSelector() {
-    // When counting global rows we can select anything; we use the ttl of the first regular
-    // column since it is an int and only takes 4 bytes; if no regular column exists, we use
-    // the first partition key column.
-    return table
-        .getColumns()
-        .stream()
-        .filter(col -> !table.getPrimaryKey().contains(col))
-        .map(col -> "TTL(" + quoteIfNecessary(col.getName()) + ")")
-        .findFirst()
-        .orElse(quoteIfNecessary(table.getPartitionKey().get(0).getName()));
+    // When counting global rows we can select anything; we use the first partition key column.
+    return quoteIfNecessary(table.getPartitionKey().get(0).getName());
   }
 
   private Set<CQLIdentifier> primaryKeyVariables() {

--- a/engine/src/test/java/com/datastax/dsbulk/engine/internal/settings/SchemaSettingsTest.java
+++ b/engine/src/test/java/com/datastax/dsbulk/engine/internal/settings/SchemaSettingsTest.java
@@ -1093,21 +1093,6 @@ class SchemaSettingsTest {
     ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
     verify(session).prepare(argument.capture());
     assertThat(argument.getValue())
-        .isEqualTo("SELECT TTL(c3) FROM ks.t1 WHERE token(c1) > :start AND token(c1) <= :end");
-  }
-
-  @Test
-  void should_create_row_counter_for_global_stats_no_regular_column() {
-    when(table.getPrimaryKey()).thenReturn(newArrayList(col1, col2, col3));
-    LoaderConfig config = makeLoaderConfig("keyspace=ks, table=t1");
-    SchemaSettings schemaSettings = new SchemaSettings(config);
-    schemaSettings.init(WorkflowType.COUNT, cluster, false);
-    ReadResultCounter counter =
-        schemaSettings.createReadResultCounter(session, codecRegistry, EnumSet.of(global), 10);
-    assertThat(counter).isNotNull();
-    ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
-    verify(session).prepare(argument.capture());
-    assertThat(argument.getValue())
         .isEqualTo("SELECT c1 FROM ks.t1 WHERE token(c1) > :start AND token(c1) <= :end");
   }
 


### PR DESCRIPTION
When a table's first regular column is a non-frozen collection, it is
not possible to extract its TTL.