### PR TITLE
DAT-510: Port performance tests from ctool to fallout	

### DIFF
--- a/perf/fallout/setupFalloutPerfTest.yaml
+++ b/perf/fallout/setupFalloutPerfTest.yaml
@@ -1,6 +1,5 @@
 # branch and version of the dsbulk to benchmark
 branch: "1.x"
-version: "1.5.1-SNAPSHOT"
 # type of connector that should be performance tested, could be json or csv.
 type_of_test: "csv"
 


### PR DESCRIPTION
This is an example run for `"json"` : https://fallout.sjc.dsinternal.org/tests/ui/tomasz.lelek@datastax.com/dsbulk_performance_test/66490649-4f81-4539-9a47-006663666c14/artifacts (it failed because not all load steps finished with 0 return code).
The results are published as the fallout artifacts, see `dsbulk-client.node0` section for files with output logs. They will be persisted between runs.