### PR TITLE
DAT-402: Create an abstract RecordReader leveraging Flux.generate

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,8 +1,9 @@
 ## Changelog
 
-## 1.5.1 (in progress)
+## 1.6.0 (in progress)
 
 - [bug] DAT-558: Count operations should not modify user-provided queries.
+- [improvement] DAT-402: Create an abstract RecordReader leveraging Flux.generate.
 
 
 ## 1.5.0

--- a/connectors/csv/src/test/java/com/datastax/oss/dsbulk/connectors/csv/CSVConnectorTest.java
+++ b/connectors/csv/src/test/java/com/datastax/oss/dsbulk/connectors/csv/CSVConnectorTest.java
@@ -234,6 +234,11 @@ class CSVConnectorTest {
             "Venture \"Extended Edition\"",
             "",
             "4900.00");
+    assertThat(actual.get(0).getPosition()).isEqualTo(1L);
+    assertThat(actual.get(1).getPosition()).isEqualTo(2L);
+    assertThat(actual.get(2).getPosition()).isEqualTo(3L);
+    assertThat(actual.get(3).getPosition()).isEqualTo(4L);
+    assertThat(actual.get(4).getPosition()).isEqualTo(5L);
   }
 
   @Test
@@ -252,6 +257,8 @@ class CSVConnectorTest {
       List<Record> actual = Flux.from(connector.read()).collectList().block();
       assertThat(actual).hasSize(1);
       assertThat(actual.get(0).getSource()).isEqualTo(line);
+      assertThat(actual.get(0).getResource()).isEqualTo(URI.create("std:/"));
+      assertThat(actual.get(0).getPosition()).isEqualTo(1L);
       assertThat(actual.get(0).values()).containsExactly("fóô", "bàr", "qïx");
       connector.close();
     } finally {

--- a/connectors/json/src/test/java/com/datastax/oss/dsbulk/connectors/json/JsonConnectorTest.java
+++ b/connectors/json/src/test/java/com/datastax/oss/dsbulk/connectors/json/JsonConnectorTest.java
@@ -250,6 +250,8 @@ class JsonConnectorTest {
       List<Record> actual = Flux.from(connector.read()).collectList().block();
       assertThat(actual).hasSize(1);
       assertThat(actual.get(0).getSource()).isEqualTo(objectMapper.readTree(line));
+      assertThat(actual.get(0).getResource()).isEqualTo(URI.create("std:/"));
+      assertThat(actual.get(0).getPosition()).isEqualTo(1L);
       assertThat(actual.get(0).getFieldValue(new DefaultMappedField("fóô")))
           .isEqualTo(factory.textNode("bàr"));
       assertThat(actual.get(0).getFieldValue(new DefaultMappedField("qïx")))
@@ -1226,6 +1228,11 @@ class JsonConnectorTest {
             factory.textNode("Venture \"Extended Edition\""),
             factory.nullNode(),
             factory.numberNode(4900.00d));
+    assertThat(actual.get(0).getPosition()).isEqualTo(1L);
+    assertThat(actual.get(1).getPosition()).isEqualTo(2L);
+    assertThat(actual.get(2).getPosition()).isEqualTo(3L);
+    assertThat(actual.get(3).getPosition()).isEqualTo(4L);
+    assertThat(actual.get(4).getPosition()).isEqualTo(5L);
   }
 
   private List<Record> createRecords() {


### PR DESCRIPTION
Numbers looking good, so I'll merge this PR soon:

  | DAT-402 | 1.x
-- | -- | --
  | rows/sec | rows/sec
100b_parallel | 170,968 | 171,758
100b_tpc | 197,008 | 197,934
10kb | 22,450 | 22,953
10 cols | 324,541 | 316,241
1kb | 153,176 | 165,132
1mb | 219 | 216
trans parallel | 357,093 | 327,784
trans tpc | 513,414 | 492,199

