### PR TITLE
[issue-371] fix when first line doesn't contain version

### DIFF
--- a/bin/dsbulk
+++ b/bin/dsbulk
@@ -41,7 +41,7 @@ SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
 for J in "$JAVA" "$JAVA_HOME"/bin/java "$(/usr/libexec/java_home 2> /dev/null)/bin/java" $(command -v java) ; do
   if [ ! -z "$J" -a -x "$J" ]; then
-    VER=$($J -version 2>&1 | head -1 | sed -e 's/[^"]*"//' -e 's/".*//' -e 's/\.[^\.]*$//')
+    VER=$($J -version 2>&1 | grep -i version | head -1 | sed -e 's/[^"]*"//' -e 's/".*//' -e 's/\.[^\.]*$//')
     MAJOR=$(echo $VER | sed -e 's/\..*$//')
     MINOR=$(echo $VER | sed -e 's/^.*\.//')
     # matches 1.8, 1.9, 1.10 etc. as well as 8, 9, 10...

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -3,6 +3,7 @@
 ## 1.6.1 (in progress)
 
 - [bug] Correctly display durations lesser than 1 second (#369).
+- [bug] Skip invalid lines when parsing the output of java -version (#372, fixes #371).
 
 
 ## 1.6.0


### PR DESCRIPTION
This change forces to get first line that contains `version` string.

this should fix #371