### PR TITLE
Fix wrong ANSI mode option name

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+## 1.9.1 (in progress)
+
+- [bug] [#419](https://github.com/datastax/dsbulk/issues/419): Fix wrong ANSI mode option name.
+
 ## 1.9.0
 
 - [improvement] Upgrade driver to 4.14.0.

--- a/manual/application.template.conf
+++ b/manual/application.template.conf
@@ -1435,11 +1435,7 @@ dsbulk {
     # - a standard Windows DOS command prompt (ANSI sequences are translated on the fly).
     # - `force`: DSBulk will use ANSI, even if the terminal has not been detected as
     # ANSI-compatible.
-    # - `disable`: DSBulk will not use ANSI.
-    # 
-    # Note to Windows users: ANSI support on Windows works best when the Microsoft Visual C++ 2008
-    # SP1 Redistributable Package is installed; you can download it
-    # [here](https://www.microsoft.com/en-us/download/details.aspx?displaylang=en&id=5582).
+    # - `disabled`: DSBulk will not use ANSI.
     # Type: string
     # Default value: "normal"
     #log.ansiMode = "normal"

--- a/manual/settings.md
+++ b/manual/settings.md
@@ -1273,9 +1273,7 @@ Whether or not to use ANSI colors and other escape sequences in log messages pri
   - compatible with ANSI escape sequences; all common terminals on *nix and BSD systems, including MacOS, are ANSI-compatible, and some popular terminals for Windows (Mintty, MinGW);
   - a standard Windows DOS command prompt (ANSI sequences are translated on the fly).
 - `force`: DSBulk will use ANSI, even if the terminal has not been detected as ANSI-compatible.
-- `disable`: DSBulk will not use ANSI.
-
-Note to Windows users: ANSI support on Windows works best when the Microsoft Visual C++ 2008 SP1 Redistributable Package is installed; you can download it [here](https://www.microsoft.com/en-us/download/details.aspx?displaylang=en&id=5582).
+- `disabled`: DSBulk will not use ANSI.
 
 Default: **"normal"**.
 

--- a/runner/src/main/java/com/datastax/oss/dsbulk/runner/DataStaxBulkLoader.java
+++ b/runner/src/main/java/com/datastax/oss/dsbulk/runner/DataStaxBulkLoader.java
@@ -18,7 +18,6 @@ package com.datastax.oss.dsbulk.runner;
 import static com.datastax.oss.dsbulk.runner.ExitStatus.STATUS_CRASHED;
 import static com.datastax.oss.dsbulk.runner.ExitStatus.STATUS_OK;
 
-import com.datastax.oss.dsbulk.runner.cli.AnsiConfigurator;
 import com.datastax.oss.dsbulk.runner.cli.CommandLineParser;
 import com.datastax.oss.dsbulk.runner.cli.GlobalHelpRequestException;
 import com.datastax.oss.dsbulk.runner.cli.ParsedCommandLine;
@@ -59,8 +58,6 @@ public class DataStaxBulkLoader {
 
     Workflow workflow = null;
     try {
-
-      AnsiConfigurator.configureAnsi(args);
 
       CommandLineParser parser = new CommandLineParser(args);
       ParsedCommandLine result = parser.parse();

--- a/runner/src/main/java/com/datastax/oss/dsbulk/runner/cli/CommandLineParser.java
+++ b/runner/src/main/java/com/datastax/oss/dsbulk/runner/cli/CommandLineParser.java
@@ -75,6 +75,8 @@ public class CommandLineParser {
 
     checkVersionRequest();
 
+    AnsiConfigurator.configureAnsi(args);
+
     Path applicationPath = resolveApplicationPath();
     String connectorName = resolveConnectorName();
 
@@ -139,7 +141,9 @@ public class CommandLineParser {
     Iterator<String> iterator = args.iterator();
     while (iterator.hasNext()) {
       String arg = iterator.next();
-      if (arg.equals("-c") || arg.equals("--connector.name")) {
+      if (arg.equals("-c")
+          || arg.equals("--connector.name")
+          || arg.equals("--dsbulk.connector.name")) {
         if (iterator.hasNext()) {
           return iterator.next();
         } else {
@@ -193,7 +197,9 @@ public class CommandLineParser {
   private boolean skipConnector(ListIterator<String> it) {
     if (it.hasNext()) {
       String arg = it.next();
-      if (arg.equals("-c") || arg.equals("--connector.name")) {
+      if (arg.equals("-c")
+          || arg.equals("--connector.name")
+          || arg.equals("--dsbulk.connector.name")) {
         it.next(); // already validated that there is at least one more arg
       } else {
         it.previous();

--- a/runner/src/test/java/com/datastax/oss/dsbulk/runner/cli/AnsiConfiguratorTest.java
+++ b/runner/src/test/java/com/datastax/oss/dsbulk/runner/cli/AnsiConfiguratorTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.dsbulk.runner.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class AnsiConfiguratorTest {
+
+  @BeforeEach
+  @AfterEach
+  void clearProperties() {
+    System.clearProperty("jansi.strip");
+    System.clearProperty("jansi.force");
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void should_detect_ansi_mode(
+      List<String> args, String expectedJansiStrip, String expectedJansiForce)
+      throws ParseException {
+
+    AnsiConfigurator.configureAnsi(args);
+
+    assertThat(System.getProperty("jansi.strip")).isEqualTo(expectedJansiStrip);
+    assertThat(System.getProperty("jansi.force")).isEqualTo(expectedJansiForce);
+  }
+
+  static Stream<Arguments> should_detect_ansi_mode() {
+    return Stream.of(
+        Arguments.of(Arrays.asList("--log.ansiMode", "disabled"), "true", null),
+        Arguments.of(Arrays.asList("--dsbulk.log.ansiMode", "disabled"), "true", null),
+        Arguments.of(Arrays.asList("--log.ansiMode", "force"), null, "true"),
+        Arguments.of(Arrays.asList("--dsbulk.log.ansiMode", "force"), null, "true"),
+        Arguments.of(Collections.singletonList("--log.ansiMode=disabled"), "true", null),
+        Arguments.of(Collections.singletonList("--dsbulk.log.ansiMode=disabled"), "true", null),
+        Arguments.of(Collections.singletonList("--log.ansiMode=force"), null, "true"),
+        Arguments.of(Collections.singletonList("--dsbulk.log.ansiMode=force"), null, "true"));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void should_fail_when_incorrect_config(List<String> args, String expectedMessage) {
+    Throwable t = catchThrowable(() -> AnsiConfigurator.configureAnsi(args));
+    assertThat(t).isInstanceOf(ParseException.class).hasMessageContaining(expectedMessage);
+  }
+
+  static Stream<Arguments> should_fail_when_incorrect_config() {
+    return Stream.of(
+        // missing value
+        Arguments.of(
+            Collections.singletonList("--log.ansiMode"), "Expecting value after: --log.ansiMode"),
+        Arguments.of(
+            Collections.singletonList("--dsbulk.log.ansiMode"),
+            "Expecting value after: --dsbulk.log.ansiMode"),
+        // invalid value
+        Arguments.of(
+            Arrays.asList("--log.ansiMode", "INCORRECT"), "Invalid value for --log.ansiMode"),
+        Arguments.of(
+            Arrays.asList("--dsbulk.log.ansiMode", "INCORRECT"),
+            "Invalid value for --dsbulk.log.ansiMode"),
+        // invalid value with key=value syntax
+        Arguments.of(
+            Collections.singletonList("--log.ansiMode=INCORRECT"),
+            "Invalid value for --log.ansiMode"),
+        Arguments.of(
+            Collections.singletonList("--dsbulk.log.ansiMode=INCORRECT"),
+            "Invalid value for --dsbulk.log.ansiMode"));
+  }
+}

--- a/workflow/commons/src/main/resources/dsbulk-reference.conf
+++ b/workflow/commons/src/main/resources/dsbulk-reference.conf
@@ -437,9 +437,7 @@ dsbulk {
     #   - compatible with ANSI escape sequences; all common terminals on *nix and BSD systems, including MacOS, are ANSI-compatible, and some popular terminals for Windows (Mintty, MinGW);
     #   - a standard Windows DOS command prompt (ANSI sequences are translated on the fly).
     # - `force`: DSBulk will use ANSI, even if the terminal has not been detected as ANSI-compatible.
-    # - `disable`: DSBulk will not use ANSI.
-    #
-    # Note to Windows users: ANSI support on Windows works best when the Microsoft Visual C++ 2008 SP1 Redistributable Package is installed; you can download it [here](https://www.microsoft.com/en-us/download/details.aspx?displaylang=en&id=5582).
+    # - `disabled`: DSBulk will not use ANSI.
     ansiMode = normal
 
     # Settings controlling how statements are printed to log files.


### PR DESCRIPTION
Fixes #419.

This commit also:

- Enforces that the value for --log.ansiMode is valid;
- Adds missing support for --dsbulk.log.ansiMode;
- Adds missing support for --dsbulk.connector.name;
- Adds unit tests for AnsiConfigurator.