### PR TITLE
Don't print count results if read result counter is null

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 - [improvement] Upgrade driver to 4.14.1.
 - [bug] [#419](https://github.com/datastax/dsbulk/issues/419): Fix wrong ANSI mode option name.
+- [bug] [#425](https://github.com/datastax/dsbulk/issues/425): Don't print count results if read result counter is null.
 
 ## 1.9.0
 

--- a/workflow/count/src/main/java/com/datastax/oss/dsbulk/workflow/count/CountWorkflow.java
+++ b/workflow/count/src/main/java/com/datastax/oss/dsbulk/workflow/count/CountWorkflow.java
@@ -210,13 +210,14 @@ public class CountWorkflow implements Workflow {
       // Print results even if any failures.
       // It has no sense to query billions rows for a few hours and show nothing if some failure
       // happens
-      readResultCounter.reportTotals();
-      if (!success) {
-        LOGGER.warn(
-            "Please note: the totals reported above are probably inaccurate, "
-                + "since the operation completed with errors.");
+      if (readResultCounter != null) {
+        readResultCounter.reportTotals();
+        if (!success) {
+          LOGGER.warn(
+              "Please note: the totals reported above are probably inaccurate, "
+                  + "since the operation completed with errors.");
+        }
       }
-
       LOGGER.debug("{} closed.", this);
       if (e != null) {
         throw e;


### PR DESCRIPTION
Fixes #425.