### PR TITLE
Add JSON Codec for Vector type

### DIFF
--- a/codecs/text/src/main/java/com/datastax/oss/dsbulk/codecs/text/json/JsonNodeToCqlVectorCodec.java
+++ b/codecs/text/src/main/java/com/datastax/oss/dsbulk/codecs/text/json/JsonNodeToCqlVectorCodec.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.dsbulk.codecs.text.json;
+
+import com.datastax.oss.driver.api.core.data.CqlVector;
+import com.datastax.oss.driver.api.core.type.CqlVectorType;
+import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
+import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
+import com.datastax.oss.dsbulk.codecs.api.ConvertingCodec;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import java.util.List;
+
+public class JsonNodeToCqlVectorCodec<E> extends JsonNodeConvertingCodec<CqlVector<E>> {
+
+  private final ConvertingCodec<JsonNode, E> eltCodec;
+  private final ObjectMapper objectMapper;
+
+  public JsonNodeToCqlVectorCodec(
+      CqlVectorType cqlType,
+      ConvertingCodec<JsonNode, E> eltCodec,
+      TypeCodec<E> typeCodec,
+      ObjectMapper objectMapper,
+      List<String> nullStrings) {
+    super(TypeCodecs.vectorOf(cqlType, typeCodec), nullStrings);
+    this.eltCodec = eltCodec;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public CqlVector<E> externalToInternal(JsonNode jsonNode) {
+    if (jsonNode.isArray()) {
+      CqlVector.Builder<E> builder = CqlVector.builder();
+      jsonNode
+          .elements()
+          .forEachRemaining(
+              item -> {
+                E e = eltCodec.externalToInternal(item);
+                builder.add(e);
+              });
+      return builder.build();
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public JsonNode internalToExternal(CqlVector<E> value) {
+    if (value == null) {
+      return null;
+    }
+    ArrayNode root = objectMapper.createArrayNode();
+    for (E element : value.getValues()) {
+      root.add(eltCodec.internalToExternal(element));
+    }
+    return root;
+  }
+}

--- a/codecs/text/src/main/java/com/datastax/oss/dsbulk/codecs/text/string/StringToVectorCodec.java
+++ b/codecs/text/src/main/java/com/datastax/oss/dsbulk/codecs/text/string/StringToVectorCodec.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.dsbulk.codecs.text.string;
+
+import com.datastax.oss.driver.api.core.data.CqlVector;
+import com.datastax.oss.driver.internal.core.type.codec.CqlVectorCodec;
+import java.util.List;
+
+public class StringToVectorCodec<SubtypeT> extends StringConvertingCodec<CqlVector<SubtypeT>> {
+
+  public StringToVectorCodec(CqlVectorCodec<SubtypeT> subcodec, List<String> nullStrings) {
+    super(subcodec, nullStrings);
+  }
+
+  @Override
+  public CqlVector<SubtypeT> externalToInternal(String s) {
+    return this.internalCodec.parse(s);
+  }
+
+  @Override
+  public String internalToExternal(CqlVector<SubtypeT> cqlVector) {
+    return this.internalCodec.format(cqlVector);
+  }
+}

--- a/codecs/text/src/test/java/com/datastax/oss/dsbulk/codecs/text/string/StringToVectorCodecTest.java
+++ b/codecs/text/src/test/java/com/datastax/oss/dsbulk/codecs/text/string/StringToVectorCodecTest.java
@@ -1,4 +1,21 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.datastax.oss.dsbulk.codecs.text.string;
+
+import static com.datastax.oss.dsbulk.tests.assertions.TestAssertions.assertThat;
 
 import com.datastax.oss.driver.api.core.data.CqlVector;
 import com.datastax.oss.driver.api.core.type.CqlVectorType;
@@ -6,57 +23,52 @@ import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
 import com.datastax.oss.driver.internal.core.type.codec.CqlVectorCodec;
 import com.datastax.oss.driver.shaded.guava.common.collect.Lists;
-import org.junit.jupiter.api.Test;
-
 import java.util.ArrayList;
-
-import static com.datastax.oss.dsbulk.tests.assertions.TestAssertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 public class StringToVectorCodecTest {
 
-    private final ArrayList<Float> values = Lists.newArrayList(1.1f, 2.2f, 3.3f, 4.4f, 5.5f);
-    private final CqlVector vector = CqlVector.builder().addAll(values).build();
-    private final CqlVectorCodec vectorCodec = new CqlVectorCodec(
-            new CqlVectorType(DataTypes.FLOAT, 5),
-            TypeCodecs.FLOAT);
+  private final ArrayList<Float> values = Lists.newArrayList(1.1f, 2.2f, 3.3f, 4.4f, 5.5f);
+  private final CqlVector vector = CqlVector.builder().addAll(values).build();
+  private final CqlVectorCodec vectorCodec =
+      new CqlVectorCodec(new CqlVectorType(DataTypes.FLOAT, 5), TypeCodecs.FLOAT);
 
-    private final StringToVectorCodec dsbulkCodec = new StringToVectorCodec(
-            vectorCodec,
-            Lists.newArrayList("NULL"));
+  private final StringToVectorCodec dsbulkCodec =
+      new StringToVectorCodec(vectorCodec, Lists.newArrayList("NULL"));
 
-    @Test
-    void should_convert_from_valid_external() {
-        assertThat(dsbulkCodec)
-                .convertsFromExternal(vectorCodec.format(vector)) // standard pattern
-                .toInternal(vector)
-                .convertsFromExternal("")
-                .toInternal(null)
-                .convertsFromExternal(null)
-                .toInternal(null)
-                .convertsFromExternal("NULL")
-                .toInternal(null);
-    }
+  @Test
+  void should_convert_from_valid_external() {
+    assertThat(dsbulkCodec)
+        .convertsFromExternal(vectorCodec.format(vector)) // standard pattern
+        .toInternal(vector)
+        .convertsFromExternal("")
+        .toInternal(null)
+        .convertsFromExternal(null)
+        .toInternal(null)
+        .convertsFromExternal("NULL")
+        .toInternal(null);
+  }
 
-    @Test
-    void should_convert_from_valid_internal() {
-        assertThat(dsbulkCodec)
-                .convertsFromInternal(vector)
-                .toExternal(vectorCodec.format(vector))
-                .convertsFromInternal(null)
-                .toExternal("NULL");
-    }
+  @Test
+  void should_convert_from_valid_internal() {
+    assertThat(dsbulkCodec)
+        .convertsFromInternal(vector)
+        .toExternal(vectorCodec.format(vector))
+        .convertsFromInternal(null)
+        .toExternal("NULL");
+  }
 
-    @Test
-    void should_not_convert_from_invalid_external() {
-        // Too few values to match dimensions
-        ArrayList<Float> tooMany = Lists.newArrayList(values);
-        tooMany.add(6.6f);
-        ArrayList<Float> tooFew = Lists.newArrayList(values);
-        tooFew.remove(0);
+  @Test
+  void should_not_convert_from_invalid_external() {
+    // Too few values to match dimensions
+    ArrayList<Float> tooMany = Lists.newArrayList(values);
+    tooMany.add(6.6f);
+    ArrayList<Float> tooFew = Lists.newArrayList(values);
+    tooFew.remove(0);
 
-        assertThat(dsbulkCodec)
-                .cannotConvertFromExternal(CqlVector.builder().addAll(tooMany).build())
-                .cannotConvertFromExternal(CqlVector.builder().addAll(tooFew).build())
-                .cannotConvertFromExternal("not a valid vector");
-    }
+    assertThat(dsbulkCodec)
+        .cannotConvertFromExternal(CqlVector.builder().addAll(tooMany).build())
+        .cannotConvertFromExternal(CqlVector.builder().addAll(tooFew).build())
+        .cannotConvertFromExternal("not a valid vector");
+  }
 }

--- a/codecs/text/src/test/java/com/datastax/oss/dsbulk/codecs/text/string/StringToVectorCodecTest.java
+++ b/codecs/text/src/test/java/com/datastax/oss/dsbulk/codecs/text/string/StringToVectorCodecTest.java
@@ -1,0 +1,62 @@
+package com.datastax.oss.dsbulk.codecs.text.string;
+
+import com.datastax.oss.driver.api.core.data.CqlVector;
+import com.datastax.oss.driver.api.core.type.CqlVectorType;
+import com.datastax.oss.driver.api.core.type.DataTypes;
+import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
+import com.datastax.oss.driver.internal.core.type.codec.CqlVectorCodec;
+import com.datastax.oss.driver.shaded.guava.common.collect.Lists;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static com.datastax.oss.dsbulk.tests.assertions.TestAssertions.assertThat;
+
+public class StringToVectorCodecTest {
+
+    private final ArrayList<Float> values = Lists.newArrayList(1.1f, 2.2f, 3.3f, 4.4f, 5.5f);
+    private final CqlVector vector = CqlVector.builder().addAll(values).build();
+    private final CqlVectorCodec vectorCodec = new CqlVectorCodec(
+            new CqlVectorType(DataTypes.FLOAT, 5),
+            TypeCodecs.FLOAT);
+
+    private final StringToVectorCodec dsbulkCodec = new StringToVectorCodec(
+            vectorCodec,
+            Lists.newArrayList("NULL"));
+
+    @Test
+    void should_convert_from_valid_external() {
+        assertThat(dsbulkCodec)
+                .convertsFromExternal(vectorCodec.format(vector)) // standard pattern
+                .toInternal(vector)
+                .convertsFromExternal("")
+                .toInternal(null)
+                .convertsFromExternal(null)
+                .toInternal(null)
+                .convertsFromExternal("NULL")
+                .toInternal(null);
+    }
+
+    @Test
+    void should_convert_from_valid_internal() {
+        assertThat(dsbulkCodec)
+                .convertsFromInternal(vector)
+                .toExternal(vectorCodec.format(vector))
+                .convertsFromInternal(null)
+                .toExternal("NULL");
+    }
+
+    @Test
+    void should_not_convert_from_invalid_external() {
+        // Too few values to match dimensions
+        ArrayList<Float> tooMany = Lists.newArrayList(values);
+        tooMany.add(6.6f);
+        ArrayList<Float> tooFew = Lists.newArrayList(values);
+        tooFew.remove(0);
+
+        assertThat(dsbulkCodec)
+                .cannotConvertFromExternal(CqlVector.builder().addAll(tooMany).build())
+                .cannotConvertFromExternal(CqlVector.builder().addAll(tooFew).build())
+                .cannotConvertFromExternal("not a valid vector");
+    }
+}

--- a/cql/src/main/antlr4/com/datastax/oss/dsbulk/generated/cql3/Cql.g4
+++ b/cql/src/main/antlr4/com/datastax/oss/dsbulk/generated/cql3/Cql.g4
@@ -449,6 +449,7 @@ relation
     | cident K_IN singleColumnInValues
     | cident K_CONTAINS (K_KEY)? term
     | cident '[' term ']' relationType term
+    | cident K_ANN_OF term
     | tupleOfIdentifiers
       ( K_IN
           ( '(' ')'
@@ -639,6 +640,7 @@ K_TOKEN:       T O K E N;
 K_WRITETIME:   W R I T E T I M E;
 K_DATE:        D A T E;
 K_TIME:        T I M E;
+K_VECTOR:      V E C T O R;
 
 K_NULL:        N U L L;
 K_NOT:         N O T;
@@ -656,6 +658,8 @@ K_JSON:        J S O N;
 K_DEFAULT:     D E F A U L T;
 K_UNSET:       U N S E T;
 K_LIKE:        L I K E;
+
+K_ANN_OF:      A N N WS+ O F;
 
 // Case-insensitive alpha characters
 fragment A: ('a'|'A');

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     make sure the resulting binary tarball contains only
     required jars, and that no jar has an offending license.
     -->
-    <driver.version>4.14.1</driver.version>
+    <driver.version>4.16.0</driver.version>
     <reactive-streams.version>1.0.3</reactive-streams.version>
     <reactor.version>2020.0.19</reactor.version>
     <config.version>1.4.2</config.version>


### PR DESCRIPTION
This patch is based on https://github.com/datastax/dsbulk/pull/475

It adds the implementation for [JsonNodeToCqlVectorCodec.java](https://github.com/datastax/dsbulk/compare/1.x...eolivelli:dsbulk:json-vector-codec?expand=1#diff-04aa82ad729344e2faaccae4cf90a646a4ddbddc41e3c159d7a5a7ba6003cfff), that allows users to deal with the new CqlVector data type