### PR TITLE
Prevent insert queries from failing to parse when using "vector" as a column name

### DIFF
--- a/cql/src/main/antlr4/com/datastax/oss/dsbulk/generated/cql3/Cql.g4
+++ b/cql/src/main/antlr4/com/datastax/oss/dsbulk/generated/cql3/Cql.g4
@@ -449,7 +449,7 @@ relation
     | cident K_IN singleColumnInValues
     | cident K_CONTAINS (K_KEY)? term
     | cident '[' term ']' relationType term
-    | cident K_ANN_OF term
+    | cident K_ANN K_OF term
     | tupleOfIdentifiers
       ( K_IN
           ( '(' ')'
@@ -499,6 +499,7 @@ comparatorType
     | collectionType
     | tupleType
     | userTypeName
+    | vectorType
     | K_FROZEN '<' comparatorType '>'
     ;
 
@@ -524,7 +525,6 @@ nativeType
     | K_TIMEUUID
     | K_DATE
     | K_TIME
-    | K_VECTOR
     ;
 
 collectionType
@@ -537,6 +537,9 @@ tupleType
     : K_TUPLE '<' comparatorType (',' comparatorType)* '>'
     ;
 
+vectorType
+    : K_VECTOR '<' comparatorType ',' INTEGER '>'
+    ;
 
 // Basically the same as cident, but we need to exlude existing CQL3 types
 // (which for some reason are not reserved otherwise)
@@ -573,6 +576,8 @@ basicUnreservedKeyword
         | K_PER
         | K_PARTITION
         | K_GROUP
+        | K_VECTOR
+        | K_ANN
         )
     ;
 
@@ -660,7 +665,8 @@ K_DEFAULT:     D E F A U L T;
 K_UNSET:       U N S E T;
 K_LIKE:        L I K E;
 
-K_ANN_OF:      A N N WS+ O F;
+K_ANN:         A N N;
+K_OF:          O F;
 
 // Case-insensitive alpha characters
 fragment A: ('a'|'A');

--- a/cql/src/main/antlr4/com/datastax/oss/dsbulk/generated/cql3/Cql.g4
+++ b/cql/src/main/antlr4/com/datastax/oss/dsbulk/generated/cql3/Cql.g4
@@ -524,6 +524,7 @@ nativeType
     | K_TIMEUUID
     | K_DATE
     | K_TIME
+    | K_VECTOR
     ;
 
 collectionType

--- a/workflow/commons/src/test/java/com/datastax/oss/dsbulk/workflow/commons/schema/QueryInspectorTest.java
+++ b/workflow/commons/src/test/java/com/datastax/oss/dsbulk/workflow/commons/schema/QueryInspectorTest.java
@@ -34,8 +34,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.management.Query;
-
 class QueryInspectorTest {
 
   private static final CQLWord NOW = CQLWord.fromInternal("now");

--- a/workflow/commons/src/test/java/com/datastax/oss/dsbulk/workflow/commons/schema/QueryInspectorTest.java
+++ b/workflow/commons/src/test/java/com/datastax/oss/dsbulk/workflow/commons/schema/QueryInspectorTest.java
@@ -657,6 +657,17 @@ class QueryInspectorTest {
 
   @ParameterizedTest
   @MethodSource
+  void should_detect_unsupported_vector_selector(String query, boolean expected) {
+    assertThat(new QueryInspector(query).hasUnsupportedSelectors()).isEqualTo(expected);
+  }
+
+  @SuppressWarnings("unused")
+  static List<Arguments> should_detect_unsupported_vector_selector() {
+    return Lists.newArrayList(arguments("SELECT (vector<int,3>)[0.123] FROM ks.t1", true));
+  }
+
+  @ParameterizedTest
+  @MethodSource
   void should_detect_functions_in_assignments(
       String query, int expectedTotalAssignments, FunctionCall expectedValue) {
     QueryInspector inspector = new QueryInspector(query);

--- a/workflow/commons/src/test/java/com/datastax/oss/dsbulk/workflow/commons/schema/QueryInspectorTest.java
+++ b/workflow/commons/src/test/java/com/datastax/oss/dsbulk/workflow/commons/schema/QueryInspectorTest.java
@@ -34,6 +34,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import javax.management.Query;
+
 class QueryInspectorTest {
 
   private static final CQLWord NOW = CQLWord.fromInternal("now");
@@ -655,15 +657,11 @@ class QueryInspectorTest {
         arguments("SELECT * FROM ks.t1", false));
   }
 
-  @ParameterizedTest
-  @MethodSource
-  void should_detect_unsupported_vector_selector(String query, boolean expected) {
-    assertThat(new QueryInspector(query).hasUnsupportedSelectors()).isEqualTo(expected);
-  }
-
-  @SuppressWarnings("unused")
-  static List<Arguments> should_detect_unsupported_vector_selector() {
-    return Lists.newArrayList(arguments("SELECT (vector<int,3>)[0.123] FROM ks.t1", true));
+  @Test
+  void should_detect_unsupported_vector_selector() {
+    String query = "SELECT (vector<int,3>)[0.123] FROM ks.t1";
+    QueryInspector inspector = new QueryInspector(query);
+    assertThat(inspector.hasUnsupportedSelectors()).isTrue();
   }
 
   @ParameterizedTest

--- a/workflow/commons/src/test/java/com/datastax/oss/dsbulk/workflow/commons/schema/QueryInspectorTest.java
+++ b/workflow/commons/src/test/java/com/datastax/oss/dsbulk/workflow/commons/schema/QueryInspectorTest.java
@@ -64,6 +64,8 @@ class QueryInspectorTest {
   private static final CQLWord T_1 = CQLWord.fromInternal("t1");
   private static final CQLWord T_2 = CQLWord.fromInternal("t2");
 
+  private static final CQLWord VECTOR = CQLWord.fromInternal("vector");
+
   private static final CQLLiteral _16 = new CQLLiteral("16");
   private static final CQLLiteral _2 = new CQLLiteral("2");
   private static final CQLLiteral _3 = new CQLLiteral("3");
@@ -226,6 +228,26 @@ class QueryInspectorTest {
         .containsEntry(PK, PK)
         .containsEntry(CC, CC)
         .containsEntry(V, FUNC_NOW);
+  }
+
+  @Test
+  void should_detect_named_vector_insert() {
+    QueryInspector inspector =
+        new QueryInspector("INSERT INTO ks.table1 (pk, cc, vector) VALUES (:pk, :cc, :vector)");
+    assertThat(inspector.getAssignments())
+        .containsEntry(PK, PK)
+        .containsEntry(CC, CC)
+        .containsEntry(VECTOR, VECTOR);
+  }
+
+  @Test
+  void should_detect_positional_vector_insert() {
+    QueryInspector inspector =
+        new QueryInspector("INSERT INTO ks.table1 (pk, cc, vector) VALUES (?,?,?)");
+    assertThat(inspector.getAssignments())
+        .containsEntry(PK, PK)
+        .containsEntry(CC, CC)
+        .containsEntry(VECTOR, VECTOR);
   }
 
   @Test


### PR DESCRIPTION
Problem appeared to be that "vector" was added as a keyword but wasn't specified as an unreserved keyword.  Added it to the parsers collection of native type names which (a) [also makes it an unreserved keyword](https://github.com/datastax/dsbulk/blob/1.11.0/cql/src/main/antlr4/com/datastax/oss/dsbulk/generated/cql3/Cql.g4#L549-L557) and (b) seems more correct on it's face anyway.