### PR TITLE
Add config option to preserve null values for collections

### DIFF
--- a/codecs/api/src/main/java/com/datastax/oss/dsbulk/codecs/api/NullAllowingConvertingCodecFactory.java
+++ b/codecs/api/src/main/java/com/datastax/oss/dsbulk/codecs/api/NullAllowingConvertingCodecFactory.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.dsbulk.codecs.api;
+
+import com.datastax.oss.driver.api.core.ProtocolVersion;
+import com.datastax.oss.driver.api.core.type.DataType;
+import com.datastax.oss.driver.api.core.type.ListType;
+import com.datastax.oss.driver.api.core.type.MapType;
+import com.datastax.oss.driver.api.core.type.SetType;
+import com.datastax.oss.driver.api.core.type.codec.registry.MutableCodecRegistry;
+import com.datastax.oss.driver.api.core.type.reflect.GenericType;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.ByteBuffer;
+
+public class NullAllowingConvertingCodecFactory extends ConvertingCodecFactory {
+
+  private static class NullAllowingConvertingCodec<EXTERNAL, INTERNAL>
+      extends ConvertingCodec<EXTERNAL, INTERNAL> {
+
+    private final ConvertingCodec<EXTERNAL, INTERNAL> delegate;
+
+    private NullAllowingConvertingCodec(ConvertingCodec<EXTERNAL, INTERNAL> delegate) {
+      super(delegate.getInternalCodec(), delegate.getJavaType());
+      this.delegate = delegate;
+    }
+
+    @Override
+    public EXTERNAL decode(ByteBuffer bytes, @NonNull ProtocolVersion protocolVersion) {
+      if (bytes == null || bytes.remaining() == 0) {
+        return null;
+      }
+      return this.delegate.decode(bytes, protocolVersion);
+    }
+
+    public INTERNAL externalToInternal(EXTERNAL external) {
+      return this.delegate.externalToInternal(external);
+    }
+
+    public EXTERNAL internalToExternal(INTERNAL internal) {
+      return this.delegate.internalToExternal(internal);
+    }
+  }
+
+  private final ConvertingCodecFactory delegate;
+
+  public NullAllowingConvertingCodecFactory(ConvertingCodecFactory delegate) {
+    this.delegate = delegate;
+  }
+
+  @NonNull
+  public MutableCodecRegistry getCodecRegistry() {
+    return this.delegate.getCodecRegistry();
+  }
+
+  @NonNull
+  public ConversionContext getContext() {
+    return this.delegate.getContext();
+  }
+
+  public <EXTERNAL, INTERNAL> ConvertingCodec<EXTERNAL, INTERNAL> createConvertingCodec(
+      @NonNull DataType cqlType,
+      @NonNull GenericType<EXTERNAL> externalJavaType,
+      boolean rootCodec) {
+
+    ConvertingCodec<EXTERNAL, INTERNAL> base =
+        this.delegate.createConvertingCodec(cqlType, externalJavaType, rootCodec);
+    if (cqlType instanceof ListType || cqlType instanceof SetType || cqlType instanceof MapType) {
+      return new NullAllowingConvertingCodec<>(base);
+    }
+    return base;
+  }
+}

--- a/manual/application.template.conf
+++ b/manual/application.template.conf
@@ -674,6 +674,14 @@ dsbulk {
     # Default value: false
     #schema.allowMissingFields = false
 
+    # Whether or not null collection values (lists, sets or maps) should be converted to a null
+    # value.  By default the driver will convert these values to an empty collection.
+    #
+    # This setting is only used on unload
+    # Type: boolean
+    # Default value: false
+    #schema.allowNullCollections = false
+
     # Edge label used for loading or unloading graph data. This option can only be used for modern
     # graphs created with the Native engine (DSE 6.8+). The edge label must correspond to an
     # existing table created with the `WITH EDGE LABEL` option; also, when `edge` is specified, then

--- a/manual/application.template.conf
+++ b/manual/application.template.conf
@@ -674,14 +674,6 @@ dsbulk {
     # Default value: false
     #schema.allowMissingFields = false
 
-    # Whether or not null collection values (lists, sets or maps) should be converted to a null
-    # value.  By default the driver will convert these values to an empty collection.
-    #
-    # This setting is only used on unload
-    # Type: boolean
-    # Default value: false
-    #schema.allowNullCollections = false
-
     # Edge label used for loading or unloading graph data. This option can only be used for modern
     # graphs created with the Native engine (DSE 6.8+). The edge label must correspond to an
     # existing table created with the `WITH EDGE LABEL` option; also, when `edge` is specified, then
@@ -953,6 +945,13 @@ dsbulk {
     # 
     # When counting, these settings are ignored.
     ################################################################################################
+
+    # Whether or not null collection values (lists, sets or maps) should be converted to a null
+    # value.  By default the driver will
+    # convert these values to an empty collection.
+    # Type: boolean
+    # Default value: false
+    #codec.allowNullCollections = false
 
     # Strategy to use when converting binary data to strings. Only applicable when unloading columns
     # of CQL type `blob`, or columns of geometry types, if the value of `codec.geo` is `WKB`; and

--- a/manual/settings.md
+++ b/manual/settings.md
@@ -1,4 +1,4 @@
-# DataStax Bulk Loader v1.11.0-SNAPSHOT Options
+# DataStax Bulk Loader v1.11.1-SNAPSHOT Options
 
 *NOTE:* The long options described here can be persisted in `conf/application.conf` and thus permanently override defaults and avoid specifying options on the command line.
 
@@ -763,6 +763,15 @@ Default: **true**.
 Specify whether or not to accept records that are missing fields declared in the mapping. For example, if the mapping declares three fields A, B, and C, but a record contains only fields A and B, then if this option is true, C will be silently assigned null and the record will be considered valid, and if false, the record will be rejected. If the missing field is mapped to a primary key column, the record will always be rejected, since the database will reject the record. This setting also applies to user-defined types and tuples. Only applicable for loading, ignored otherwise.
 
 This setting is ignored when counting.
+
+Default: **false**.
+
+#### --schema.allowNullCollections<br />--dsbulk.schema.allowNullCollections _&lt;boolean&gt;_
+
+Whether or not null collection values (lists, sets or maps) should be converted to a null value.  By default the driver will
+convert these values to an empty collection.
+
+This setting is only used on unload
 
 Default: **false**.
 

--- a/manual/settings.md
+++ b/manual/settings.md
@@ -766,15 +766,6 @@ This setting is ignored when counting.
 
 Default: **false**.
 
-#### --schema.allowNullCollections<br />--dsbulk.schema.allowNullCollections _&lt;boolean&gt;_
-
-Whether or not null collection values (lists, sets or maps) should be converted to a null value.  By default the driver will
-convert these values to an empty collection.
-
-This setting is only used on unload
-
-Default: **false**.
-
 #### -e,<br />--schema.edge<br />--dsbulk.schema.edge _&lt;string&gt;_
 
 Edge label used for loading or unloading graph data. This option can only be used for modern graphs created with the Native engine (DSE 6.8+). The edge label must correspond to an existing table created with the `WITH EDGE LABEL` option; also, when `edge` is specified, then `from` and `to` must be specified as well. Edge labels should not be quoted and are case-sensitive. `MyEdge` will match a label named `MyEdge` but not `myedge`. Either `table`, `vertex` or `edge` is required if `query` is not specified.
@@ -942,6 +933,13 @@ When writing, these settings determine how record fields emitted by connectors a
 When unloading, these settings determine how row cells emitted by DSE are formatted.
 
 When counting, these settings are ignored.
+
+#### --codec.allowNullCollections<br />--dsbulk.codec.allowNullCollections _&lt;boolean&gt;_
+
+Whether or not null collection values (lists, sets or maps) should be converted to a null value.  By default the driver will
+convert these values to an empty collection.
+
+Default: **false**.
 
 #### --codec.binary<br />--dsbulk.codec.binary _&lt;string&gt;_
 

--- a/workflow/commons/src/main/java/com/datastax/oss/dsbulk/workflow/commons/settings/CodecSettings.java
+++ b/workflow/commons/src/main/java/com/datastax/oss/dsbulk/workflow/commons/settings/CodecSettings.java
@@ -19,6 +19,7 @@ import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.dsbulk.codecs.api.ConversionContext;
 import com.datastax.oss.dsbulk.codecs.api.ConvertingCodecFactory;
+import com.datastax.oss.dsbulk.codecs.api.NullAllowingConvertingCodecFactory;
 import com.datastax.oss.dsbulk.codecs.api.format.binary.Base64BinaryFormat;
 import com.datastax.oss.dsbulk.codecs.api.format.binary.BinaryFormat;
 import com.datastax.oss.dsbulk.codecs.api.format.binary.HexBinaryFormat;
@@ -199,7 +200,7 @@ public class CodecSettings {
   }
 
   public ConvertingCodecFactory createCodecFactory(
-      boolean allowExtraFields, boolean allowMissingFields) {
+      boolean allowExtraFields, boolean allowMissingFields, boolean allowNullCollections) {
     ConversionContext context =
         new TextConversionContext()
             .setObjectMapper(objectMapper)
@@ -223,7 +224,8 @@ public class CodecSettings {
             .setGeoFormat(geoFormat)
             .setAllowExtraFields(allowExtraFields)
             .setAllowMissingFields(allowMissingFields);
-    return new ConvertingCodecFactory(context);
+    ConvertingCodecFactory base = new ConvertingCodecFactory(context);
+    return allowNullCollections ? new NullAllowingConvertingCodecFactory(base) : base;
   }
 
   public static Map<String, Boolean> getBooleanInputWords(List<String> list) {

--- a/workflow/commons/src/main/java/com/datastax/oss/dsbulk/workflow/commons/settings/CodecSettings.java
+++ b/workflow/commons/src/main/java/com/datastax/oss/dsbulk/workflow/commons/settings/CodecSettings.java
@@ -266,7 +266,7 @@ public class CodecSettings {
     return builder.build();
   }
 
-  public boolean allowsNullCollections() {
+  public boolean isAllowNullCollections() {
     return allowNullCollections;
   }
 }

--- a/workflow/commons/src/main/java/com/datastax/oss/dsbulk/workflow/commons/settings/CodecSettings.java
+++ b/workflow/commons/src/main/java/com/datastax/oss/dsbulk/workflow/commons/settings/CodecSettings.java
@@ -66,6 +66,7 @@ public class CodecSettings {
   private static final String TIME_UUID_GENERATOR = "uuidStrategy";
   private static final String BINARY = "binary";
   private static final String GEO = "geo";
+  private static final String ALLOW_NULL_COLLECTIONS = "allowNullCollections";
 
   private final Config config;
 
@@ -88,9 +89,12 @@ public class CodecSettings {
   private Map<Boolean, String> booleanOutputWords;
   private BinaryFormat binaryFormat;
   private GeoFormat geoFormat;
+  private boolean allowNullCollections;
 
   public CodecSettings(Config config) {
+
     this.config = config;
+    this.allowNullCollections = config.getBoolean(ALLOW_NULL_COLLECTIONS);
   }
 
   public void init() {
@@ -260,5 +264,9 @@ public class CodecSettings {
     builder.put(true, tokenizer.nextToken().toLowerCase());
     builder.put(false, tokenizer.nextToken().toLowerCase());
     return builder.build();
+  }
+
+  public boolean allowsNullCollections() {
+    return allowNullCollections;
   }
 }

--- a/workflow/commons/src/main/java/com/datastax/oss/dsbulk/workflow/commons/settings/SchemaSettings.java
+++ b/workflow/commons/src/main/java/com/datastax/oss/dsbulk/workflow/commons/settings/SchemaSettings.java
@@ -140,6 +140,7 @@ public class SchemaSettings {
   private static final String MAPPING = "mapping";
   private static final String ALLOW_EXTRA_FIELDS = "allowExtraFields";
   private static final String ALLOW_MISSING_FIELDS = "allowMissingFields";
+  private static final String ALLOW_NULL_COLLECTIONS = "allowNullCollections";
   private static final String QUERY = "query";
   private static final String QUERY_TTL = "queryTtl";
   private static final String QUERY_TIMESTAMP = "queryTimestamp";
@@ -157,6 +158,7 @@ public class SchemaSettings {
   private boolean nullToUnset;
   private boolean allowExtraFields;
   private boolean allowMissingFields;
+  private boolean allowNullCollections;
   private int splits;
   private MappingInspector mapping;
   private int ttlSeconds;
@@ -176,6 +178,8 @@ public class SchemaSettings {
   public SchemaSettings(Config config, SchemaGenerationStrategy schemaGenerationStrategy) {
     this.config = config;
     this.schemaGenerationStrategy = schemaGenerationStrategy;
+
+    this.allowNullCollections = config.getBoolean(ALLOW_NULL_COLLECTIONS);
   }
 
   public void init(
@@ -677,6 +681,10 @@ public class SchemaSettings {
 
   public boolean isAllowMissingFields() {
     return allowMissingFields;
+  }
+
+  public boolean isAllowNullCollections() {
+    return allowNullCollections;
   }
 
   public boolean isSearchQuery() {

--- a/workflow/commons/src/main/java/com/datastax/oss/dsbulk/workflow/commons/settings/SchemaSettings.java
+++ b/workflow/commons/src/main/java/com/datastax/oss/dsbulk/workflow/commons/settings/SchemaSettings.java
@@ -140,7 +140,6 @@ public class SchemaSettings {
   private static final String MAPPING = "mapping";
   private static final String ALLOW_EXTRA_FIELDS = "allowExtraFields";
   private static final String ALLOW_MISSING_FIELDS = "allowMissingFields";
-  private static final String ALLOW_NULL_COLLECTIONS = "allowNullCollections";
   private static final String QUERY = "query";
   private static final String QUERY_TTL = "queryTtl";
   private static final String QUERY_TIMESTAMP = "queryTimestamp";
@@ -158,7 +157,6 @@ public class SchemaSettings {
   private boolean nullToUnset;
   private boolean allowExtraFields;
   private boolean allowMissingFields;
-  private boolean allowNullCollections;
   private int splits;
   private MappingInspector mapping;
   private int ttlSeconds;
@@ -178,8 +176,6 @@ public class SchemaSettings {
   public SchemaSettings(Config config, SchemaGenerationStrategy schemaGenerationStrategy) {
     this.config = config;
     this.schemaGenerationStrategy = schemaGenerationStrategy;
-
-    this.allowNullCollections = config.getBoolean(ALLOW_NULL_COLLECTIONS);
   }
 
   public void init(
@@ -681,10 +677,6 @@ public class SchemaSettings {
 
   public boolean isAllowMissingFields() {
     return allowMissingFields;
-  }
-
-  public boolean isAllowNullCollections() {
-    return allowNullCollections;
   }
 
   public boolean isSearchQuery() {

--- a/workflow/commons/src/main/resources/dsbulk-reference.conf
+++ b/workflow/commons/src/main/resources/dsbulk-reference.conf
@@ -655,6 +655,10 @@ dsbulk {
     # - WKB: Encode the data in Well-known binary format. The actual encoding will depend on the value chosen for the `codec.binary` setting (HEX or BASE64).
     # - JSON: Encode the data in GeoJson format.
     geo = WKT
+
+    # Whether or not null collection values (lists, sets or maps) should be converted to a null value.  By default the driver will
+    # convert these values to an empty collection.
+    allowNullCollections = false
   }
 
   # Monitoring-specific settings.
@@ -846,12 +850,6 @@ dsbulk {
     #
     # This setting is ignored when counting.
     allowMissingFields = false
-
-    # Whether or not null collection values (lists, sets or maps) should be converted to a null value.  By default the driver will
-    # convert these values to an empty collection.
-    #
-    # This setting is only used on unload
-    allowNullCollections = false
 
     # The Time-To-Live (TTL) of inserted/updated cells during load (seconds); a value of -1 means there is no TTL. Not applicable to unloading nor counting. Ignored when `schema.query` is provided. For more information, see the [CQL Reference](https://docs.datastax.com/en/dse/6.0/cql/cql/cql_reference/cql_commands/cqlInsert.html#cqlInsert__ime-value), [Setting the time-to-live (TTL) for value](http://docs.datastax.com/en/dse/6.0/cql/cql/cql_using/useTTL.html), and [Expiring data with time-to-live](http://docs.datastax.com/en/dse/6.0/cql/cql/cql_using/useExpire.html).
     queryTtl = -1

--- a/workflow/commons/src/main/resources/dsbulk-reference.conf
+++ b/workflow/commons/src/main/resources/dsbulk-reference.conf
@@ -847,6 +847,12 @@ dsbulk {
     # This setting is ignored when counting.
     allowMissingFields = false
 
+    # Whether or not null collection values (lists, sets or maps) should be converted to a null value.  By default the driver will
+    # convert these values to an empty collection.
+    #
+    # This setting is only used on unload
+    allowNullCollections = false
+
     # The Time-To-Live (TTL) of inserted/updated cells during load (seconds); a value of -1 means there is no TTL. Not applicable to unloading nor counting. Ignored when `schema.query` is provided. For more information, see the [CQL Reference](https://docs.datastax.com/en/dse/6.0/cql/cql/cql_reference/cql_commands/cqlInsert.html#cqlInsert__ime-value), [Setting the time-to-live (TTL) for value](http://docs.datastax.com/en/dse/6.0/cql/cql/cql_using/useTTL.html), and [Expiring data with time-to-live](http://docs.datastax.com/en/dse/6.0/cql/cql/cql_using/useExpire.html).
     queryTtl = -1
 

--- a/workflow/commons/src/test/java/com/datastax/oss/dsbulk/workflow/commons/schema/DefaultReadResultCounterTest.java
+++ b/workflow/commons/src/test/java/com/datastax/oss/dsbulk/workflow/commons/schema/DefaultReadResultCounterTest.java
@@ -202,7 +202,7 @@ class DefaultReadResultCounterTest {
     Config config = TestConfigUtils.createTestConfig("dsbulk.codec");
     CodecSettings settings = new CodecSettings(config);
     settings.init();
-    this.codecFactory = settings.createCodecFactory(false, false);
+    this.codecFactory = settings.createCodecFactory(false, false, false);
   }
 
   @Test

--- a/workflow/commons/src/test/java/com/datastax/oss/dsbulk/workflow/commons/settings/CodecSettingsTest.java
+++ b/workflow/commons/src/test/java/com/datastax/oss/dsbulk/workflow/commons/settings/CodecSettingsTest.java
@@ -19,6 +19,7 @@ import static com.datastax.oss.dsbulk.tests.assertions.TestAssertions.assertThat
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 
+import com.datastax.oss.driver.api.core.ProtocolVersion;
 import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.core.type.TupleType;
 import com.datastax.oss.driver.api.core.type.UserDefinedType;
@@ -52,8 +53,10 @@ import com.datastax.oss.dsbulk.tests.driver.DriverUtils;
 import com.datastax.oss.dsbulk.tests.utils.ReflectionUtils;
 import com.datastax.oss.dsbulk.tests.utils.TestConfigUtils;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.Maps;
 import com.typesafe.config.Config;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -172,6 +175,36 @@ class CodecSettingsTest {
     ConvertingCodec<String, Byte> codec =
         codecFactory.createConvertingCodec(DataTypes.TINYINT, GenericType.STRING, true);
     assertThat(codec.externalToInternal("128")).isEqualTo((byte) 127);
+  }
+
+  // The default case, based on functionality built into the Java driver
+  @Test
+  void should_return_codecs_that_convert_null_collections_to_empty_collections() {
+    CodecSettings settings = new CodecSettings(TestConfigUtils.createTestConfig("dsbulk.codec"));
+    settings.init();
+    ConvertingCodecFactory codecFactory = settings.createCodecFactory(false, false, false);
+    ConvertingCodec<Map<String, Integer>, Byte> codec =
+        codecFactory.createConvertingCodec(
+            DataTypes.mapOf(DataTypes.TEXT, DataTypes.INT),
+            GenericType.mapOf(GenericType.STRING, GenericType.INTEGER),
+            true);
+    assertThat(codec.decode(null, ProtocolVersion.V4)).isEqualTo(Maps.newHashMap());
+    assertThat(codec.decode(ByteBuffer.allocate(0), ProtocolVersion.V4))
+        .isEqualTo(Maps.newHashMap());
+  }
+
+  @Test
+  void should_return_codecs_that_allow_null_collections_when_specified() {
+    CodecSettings settings = new CodecSettings(TestConfigUtils.createTestConfig("dsbulk.codec"));
+    settings.init();
+    ConvertingCodecFactory codecFactory = settings.createCodecFactory(false, false, true);
+    ConvertingCodec<Map<String, Integer>, Byte> codec =
+        codecFactory.createConvertingCodec(
+            DataTypes.mapOf(DataTypes.TEXT, DataTypes.INT),
+            GenericType.mapOf(GenericType.STRING, GenericType.INTEGER),
+            true);
+    assertThat(codec.decode(null, ProtocolVersion.V4)).isEqualTo(null);
+    assertThat(codec.decode(ByteBuffer.allocate(0), ProtocolVersion.V4)).isEqualTo(null);
   }
 
   @Test

--- a/workflow/commons/src/test/java/com/datastax/oss/dsbulk/workflow/commons/settings/CodecSettingsTest.java
+++ b/workflow/commons/src/test/java/com/datastax/oss/dsbulk/workflow/commons/settings/CodecSettingsTest.java
@@ -66,7 +66,7 @@ class CodecSettingsTest {
     Config config = TestConfigUtils.createTestConfig("dsbulk.codec");
     CodecSettings settings = new CodecSettings(config);
     settings.init();
-    ConvertingCodecFactory codecFactory = settings.createCodecFactory(false, false);
+    ConvertingCodecFactory codecFactory = settings.createCodecFactory(false, false, false);
 
     assertThat(codecFactory.createConvertingCodec(DataTypes.BOOLEAN, GenericType.STRING, true))
         .isNotNull()
@@ -118,7 +118,7 @@ class CodecSettingsTest {
     Config config = TestConfigUtils.createTestConfig("dsbulk.codec");
     CodecSettings settings = new CodecSettings(config);
     settings.init();
-    ConvertingCodecFactory codecFactory = settings.createCodecFactory(false, false);
+    ConvertingCodecFactory codecFactory = settings.createCodecFactory(false, false, false);
 
     assertThat(
             codecFactory.createConvertingCodec(
@@ -156,7 +156,7 @@ class CodecSettingsTest {
             "dsbulk.codec", "roundingStrategy", "UP", "formatNumbers", "true");
     CodecSettings settings = new CodecSettings(config);
     settings.init();
-    ConvertingCodecFactory codecFactory = settings.createCodecFactory(false, false);
+    ConvertingCodecFactory codecFactory = settings.createCodecFactory(false, false, false);
     ConvertingCodec<String, Float> codec =
         codecFactory.createConvertingCodec(DataTypes.FLOAT, GenericType.STRING, true);
     assertThat(codec.internalToExternal(0.123f)).isEqualTo("0.13");
@@ -168,7 +168,7 @@ class CodecSettingsTest {
         TestConfigUtils.createTestConfig("dsbulk.codec", "overflowStrategy", "TRUNCATE");
     CodecSettings settings = new CodecSettings(config);
     settings.init();
-    ConvertingCodecFactory codecFactory = settings.createCodecFactory(false, false);
+    ConvertingCodecFactory codecFactory = settings.createCodecFactory(false, false, false);
     ConvertingCodec<String, Byte> codec =
         codecFactory.createConvertingCodec(DataTypes.TINYINT, GenericType.STRING, true);
     assertThat(codec.externalToInternal("128")).isEqualTo((byte) 127);
@@ -309,7 +309,7 @@ class CodecSettingsTest {
     Config config = TestConfigUtils.createTestConfig("dsbulk.codec");
     CodecSettings settings = new CodecSettings(config);
     settings.init();
-    ConvertingCodecFactory codecFactory = settings.createCodecFactory(false, false);
+    ConvertingCodecFactory codecFactory = settings.createCodecFactory(false, false, false);
     assertThat(
             codecFactory.createConvertingCodec(
                 DataTypes.custom("org.apache.cassandra.db.marshal.DynamicCompositeType"),

--- a/workflow/count/src/main/java/com/datastax/oss/dsbulk/workflow/count/CountWorkflow.java
+++ b/workflow/count/src/main/java/com/datastax/oss/dsbulk/workflow/count/CountWorkflow.java
@@ -114,7 +114,7 @@ public class CountWorkflow implements Workflow {
         codecSettings.createCodecFactory(
             schemaSettings.isAllowExtraFields(),
             schemaSettings.isAllowMissingFields(),
-            codecSettings.allowsNullCollections());
+            codecSettings.isAllowNullCollections());
     session =
         driverSettings.newSession(
             executionId, codecFactory.getCodecRegistry(), monitoringSettings.getRegistry());

--- a/workflow/count/src/main/java/com/datastax/oss/dsbulk/workflow/count/CountWorkflow.java
+++ b/workflow/count/src/main/java/com/datastax/oss/dsbulk/workflow/count/CountWorkflow.java
@@ -114,7 +114,7 @@ public class CountWorkflow implements Workflow {
         codecSettings.createCodecFactory(
             schemaSettings.isAllowExtraFields(),
             schemaSettings.isAllowMissingFields(),
-            schemaSettings.isAllowNullCollections());
+            codecSettings.allowsNullCollections());
     session =
         driverSettings.newSession(
             executionId, codecFactory.getCodecRegistry(), monitoringSettings.getRegistry());

--- a/workflow/count/src/main/java/com/datastax/oss/dsbulk/workflow/count/CountWorkflow.java
+++ b/workflow/count/src/main/java/com/datastax/oss/dsbulk/workflow/count/CountWorkflow.java
@@ -112,7 +112,9 @@ public class CountWorkflow implements Workflow {
     statsSettings.init();
     ConvertingCodecFactory codecFactory =
         codecSettings.createCodecFactory(
-            schemaSettings.isAllowExtraFields(), schemaSettings.isAllowMissingFields());
+            schemaSettings.isAllowExtraFields(),
+            schemaSettings.isAllowMissingFields(),
+            schemaSettings.isAllowNullCollections());
     session =
         driverSettings.newSession(
             executionId, codecFactory.getCodecRegistry(), monitoringSettings.getRegistry());

--- a/workflow/load/src/main/java/com/datastax/oss/dsbulk/workflow/load/LoadWorkflow.java
+++ b/workflow/load/src/main/java/com/datastax/oss/dsbulk/workflow/load/LoadWorkflow.java
@@ -142,7 +142,7 @@ public class LoadWorkflow implements Workflow {
         codecSettings.createCodecFactory(
             schemaSettings.isAllowExtraFields(),
             schemaSettings.isAllowMissingFields(),
-            schemaSettings.isAllowNullCollections());
+            codecSettings.allowsNullCollections());
     session =
         driverSettings.newSession(
             executionId, codecFactory.getCodecRegistry(), monitoringSettings.getRegistry());

--- a/workflow/load/src/main/java/com/datastax/oss/dsbulk/workflow/load/LoadWorkflow.java
+++ b/workflow/load/src/main/java/com/datastax/oss/dsbulk/workflow/load/LoadWorkflow.java
@@ -140,7 +140,9 @@ public class LoadWorkflow implements Workflow {
     engineSettings.init();
     ConvertingCodecFactory codecFactory =
         codecSettings.createCodecFactory(
-            schemaSettings.isAllowExtraFields(), schemaSettings.isAllowMissingFields());
+            schemaSettings.isAllowExtraFields(),
+            schemaSettings.isAllowMissingFields(),
+            schemaSettings.isAllowNullCollections());
     session =
         driverSettings.newSession(
             executionId, codecFactory.getCodecRegistry(), monitoringSettings.getRegistry());

--- a/workflow/load/src/main/java/com/datastax/oss/dsbulk/workflow/load/LoadWorkflow.java
+++ b/workflow/load/src/main/java/com/datastax/oss/dsbulk/workflow/load/LoadWorkflow.java
@@ -142,7 +142,7 @@ public class LoadWorkflow implements Workflow {
         codecSettings.createCodecFactory(
             schemaSettings.isAllowExtraFields(),
             schemaSettings.isAllowMissingFields(),
-            codecSettings.allowsNullCollections());
+            codecSettings.isAllowNullCollections());
     session =
         driverSettings.newSession(
             executionId, codecFactory.getCodecRegistry(), monitoringSettings.getRegistry());

--- a/workflow/unload/src/main/java/com/datastax/oss/dsbulk/workflow/unload/UnloadWorkflow.java
+++ b/workflow/unload/src/main/java/com/datastax/oss/dsbulk/workflow/unload/UnloadWorkflow.java
@@ -129,7 +129,7 @@ public class UnloadWorkflow implements Workflow {
         codecSettings.createCodecFactory(
             schemaSettings.isAllowExtraFields(),
             schemaSettings.isAllowMissingFields(),
-            codecSettings.allowsNullCollections());
+            codecSettings.isAllowNullCollections());
     session =
         driverSettings.newSession(
             executionId, codecFactory.getCodecRegistry(), monitoringSettings.getRegistry());

--- a/workflow/unload/src/main/java/com/datastax/oss/dsbulk/workflow/unload/UnloadWorkflow.java
+++ b/workflow/unload/src/main/java/com/datastax/oss/dsbulk/workflow/unload/UnloadWorkflow.java
@@ -129,7 +129,7 @@ public class UnloadWorkflow implements Workflow {
         codecSettings.createCodecFactory(
             schemaSettings.isAllowExtraFields(),
             schemaSettings.isAllowMissingFields(),
-            schemaSettings.isAllowNullCollections());
+            codecSettings.allowsNullCollections());
     session =
         driverSettings.newSession(
             executionId, codecFactory.getCodecRegistry(), monitoringSettings.getRegistry());

--- a/workflow/unload/src/main/java/com/datastax/oss/dsbulk/workflow/unload/UnloadWorkflow.java
+++ b/workflow/unload/src/main/java/com/datastax/oss/dsbulk/workflow/unload/UnloadWorkflow.java
@@ -127,7 +127,9 @@ public class UnloadWorkflow implements Workflow {
     executorSettings.init();
     ConvertingCodecFactory codecFactory =
         codecSettings.createCodecFactory(
-            schemaSettings.isAllowExtraFields(), schemaSettings.isAllowMissingFields());
+            schemaSettings.isAllowExtraFields(),
+            schemaSettings.isAllowMissingFields(),
+            schemaSettings.isAllowNullCollections());
     session =
         driverSettings.newSession(
             executionId, codecFactory.getCodecRegistry(), monitoringSettings.getRegistry());


### PR DESCRIPTION
The default behaviour for the Java driver is to convert null or empty values for the bytes associated with a collection to a Java type... see [here](https://github.com/apache/cassandra-java-driver/blob/4.19.2/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/MapCodec.java#L132-L134) for an example.  This behaviour is implemented within the codec layer of the Java driver meaning that by the time the data reaches dsbulk it's already been converted... so dsbulk has no means to distinguish between an empty collection generated in this way and a legit empty collection.

This PR adds a config option which loads a custom codec for collection types.  This custom codec simply returns an actual null value if null bytes (or empty bytes) are observed by the codec in the decode process.  In all other cases the default behaviour of the codec is preserved.

I've included a unit test for this functionality as well but the following manual test should be enough to demonstrate the issue (and the results of this fix):

```
CREATE TABLE test.baz (
 i int PRIMARY KEY,
 j text,
 k map<ascii,ascii>,
 l frozen<map<ascii,ascii>>
 );

insert into test.baz (i,j,k,l) values (1,'one',{},{});
insert into test.baz (i,j,k,l) values (2,'two',null,null);
insert into test.baz (i,j,k,l) values (3,'three',{'3': 'three'},{'3': 'three'});
```

```
$ bin/dsbulk unload -k test -t baz -c json 2> /dev/null
{"i":1,"j":"one","k":{},"l":{}}
{"i":2,"j":"two","k":{},"l":{}}
{"i":3,"j":"three","k":{"3":"three"},"l":{"3":"three"}}
```

```
$ bin/dsbulk unload --dsbulk.codec.allowNullCollections=true -k test -t baz -c json 2> /dev/null
{"i":1,"j":"one","k":null,"l":{}}
{"i":2,"j":"two","k":null,"l":null}
{"i":3,"j":"three","k":{"3":"three"},"l":{"3":"three"}}
```