### PR TITLE
Surface file cleanup failures

### DIFF
--- a/tests/src/main/java/com/datastax/oss/dsbulk/tests/utils/FileUtils.java
+++ b/tests/src/main/java/com/datastax/oss/dsbulk/tests/utils/FileUtils.java
@@ -101,6 +101,9 @@ public class FileUtils {
             @Override
             public FileVisitResult postVisitDirectory(Path dir, IOException exc)
                 throws IOException {
+              if (exc != null) {
+                throw exc;
+              }
               // Do not delete directories on Windows as deletes are not executed immediately,
               // but they do result in an IO exception the next time we try to access a directory in
               // pending-deletion state. Leaving directories empty is good enough for DSBulk anyway,
@@ -111,7 +114,8 @@ public class FileUtils {
               return FileVisitResult.CONTINUE;
             }
           });
-    } catch (IOException ignored) {
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
     }
   }
 


### PR DESCRIPTION
Hi. We are researchers from Mahidol University, Thailand, and the State University of Ceará, Brazil, working on a research project for improving open-source projects by using the latest accepted answer from Stack Overflow that matched your code snippet. We found this recommendation for improving your code from https://stackoverflow.com/a/18454342.

Note: Our study is approved by the Institutional Review Board of Mahidol University. You can find the participant information sheet explaining this study https://drive.google.com/file/d/1ml5AqrtWQ9pnifTQyTFTcWQmwp6RuPA7/view?usp=sharing.

----

## Proposed change

Propagate file-tree traversal failures during test cleanup instead of swallowing them and leaving misleading partial state.

<!-- Include the Testing section only when a relevant test exists and was run. Otherwise remove this comment and the entire section below. -->
